### PR TITLE
Add multi-organization management with role-based access control

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,50 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .database import get_db
+from .models import OrganizationMember, Role, User
+from .security import decode_token
+
+security = HTTPBearer(auto_error=False)
+
+
+def get_current_user(
+    db: Session = Depends(get_db),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> User:
+    if not credentials:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token")
+
+    subject = decode_token(credentials.credentials)
+    if not subject:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    user = db.scalar(select(User).where(User.email == subject))
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    return user
+
+
+def get_user_org_membership(db: Session, user: User, org_id: int) -> OrganizationMember:
+    membership = db.scalar(
+        select(OrganizationMember).where(
+            OrganizationMember.user_id == user.id,
+            OrganizationMember.organization_id == org_id,
+        )
+    )
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found or access denied",
+        )
+    return membership
+
+
+def require_org_admin(db: Session, user: User, org_id: int) -> OrganizationMember:
+    membership = get_user_org_membership(db, user, org_id)
+    if membership.role != Role.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
+    return membership

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,19 +1,41 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
 
 from .config import get_settings
 from .database import Base, engine, get_db
-from .models import User
-from .schemas import AuthResponse, Token, UserCreate, UserLogin, UserOut
-from .security import create_access_token, decode_token, hash_password, verify_password
+from .dependencies import get_current_user, get_user_org_membership, require_org_admin
+from .models import Invite, Organization, OrganizationMember, Role, User
+from .schemas import (
+    AuthResponse,
+    InviteAccept,
+    InviteCreate,
+    InviteInfo,
+    InviteOut,
+    MemberOut,
+    MemberUpdateRole,
+    OrganizationCreate,
+    OrganizationOut,
+    OrganizationUpdate,
+    Token,
+    UserCreate,
+    UserLogin,
+    UserOut,
+)
+from .security import (
+    create_access_token,
+    generate_invite_token,
+    hash_password,
+    is_invite_valid,
+    verify_password,
+)
 
 settings = get_settings()
 
 app = FastAPI(title=settings.app_name)
-security = HTTPBearer(auto_error=False)
 
 app.add_middleware(
     CORSMiddleware,
@@ -29,6 +51,11 @@ def on_startup() -> None:
     Base.metadata.create_all(bind=engine)
 
 
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
@@ -41,6 +68,11 @@ def ready(db: Session = Depends(get_db)) -> dict[str, str]:
     except Exception as exc:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database not ready") from exc
     return {"status": "ready"}
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
 
 
 @app.post("/auth/signup", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
@@ -69,19 +101,326 @@ def login(payload: UserLogin, db: Session = Depends(get_db)) -> AuthResponse:
 
 
 @app.get("/auth/me", response_model=UserOut)
-def me(
-    db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials | None = Depends(security),
-) -> UserOut:
-    if not credentials:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token")
-
-    subject = decode_token(credentials.credentials)
-    if not subject:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
-
-    user = db.scalar(select(User).where(User.email == subject))
-    if not user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-
+def me(user: User = Depends(get_current_user)) -> UserOut:
     return UserOut.model_validate(user, from_attributes=True)
+
+
+# ---------------------------------------------------------------------------
+# Organizations
+# ---------------------------------------------------------------------------
+
+
+@app.post("/organizations", response_model=OrganizationOut, status_code=status.HTTP_201_CREATED)
+def create_organization(
+    payload: OrganizationCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> OrganizationOut:
+    org = Organization(name=payload.name, created_by=user.id)
+    db.add(org)
+    db.flush()
+
+    membership = OrganizationMember(user_id=user.id, organization_id=org.id, role=Role.ADMIN)
+    db.add(membership)
+    db.commit()
+    db.refresh(org)
+
+    return OrganizationOut(
+        id=org.id, name=org.name, created_at=org.created_at, created_by=org.created_by, role=Role.ADMIN.value
+    )
+
+
+@app.get("/organizations", response_model=list[OrganizationOut])
+def list_organizations(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[OrganizationOut]:
+    memberships = (
+        db.execute(
+            select(OrganizationMember)
+            .where(OrganizationMember.user_id == user.id)
+            .options(joinedload(OrganizationMember.organization))
+        )
+        .scalars()
+        .unique()
+        .all()
+    )
+
+    return [
+        OrganizationOut(
+            id=m.organization.id,
+            name=m.organization.name,
+            created_at=m.organization.created_at,
+            created_by=m.organization.created_by,
+            role=m.role.value,
+        )
+        for m in memberships
+    ]
+
+
+@app.get("/organizations/{org_id}", response_model=OrganizationOut)
+def get_organization(
+    org_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> OrganizationOut:
+    membership = get_user_org_membership(db, user, org_id)
+    org = membership.organization
+    return OrganizationOut(
+        id=org.id, name=org.name, created_at=org.created_at, created_by=org.created_by, role=membership.role.value
+    )
+
+
+@app.patch("/organizations/{org_id}", response_model=OrganizationOut)
+def update_organization(
+    org_id: int,
+    payload: OrganizationUpdate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> OrganizationOut:
+    membership = require_org_admin(db, user, org_id)
+    org = membership.organization
+    org.name = payload.name
+    db.commit()
+    db.refresh(org)
+
+    return OrganizationOut(
+        id=org.id, name=org.name, created_at=org.created_at, created_by=org.created_by, role=membership.role.value
+    )
+
+
+@app.delete("/organizations/{org_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_organization(
+    org_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    membership = require_org_admin(db, user, org_id)
+    db.delete(membership.organization)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Members
+# ---------------------------------------------------------------------------
+
+
+@app.get("/organizations/{org_id}/members", response_model=list[MemberOut])
+def list_members(
+    org_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[MemberOut]:
+    get_user_org_membership(db, user, org_id)
+
+    members = (
+        db.execute(
+            select(OrganizationMember)
+            .where(OrganizationMember.organization_id == org_id)
+            .options(joinedload(OrganizationMember.user))
+        )
+        .scalars()
+        .unique()
+        .all()
+    )
+
+    return [
+        MemberOut(user_id=m.user.id, email=m.user.email, role=m.role.value, joined_at=m.joined_at) for m in members
+    ]
+
+
+@app.patch("/organizations/{org_id}/members/{user_id}", response_model=MemberOut)
+def update_member_role(
+    org_id: int,
+    user_id: int,
+    payload: MemberUpdateRole,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> MemberOut:
+    require_org_admin(db, user, org_id)
+
+    member = db.scalar(
+        select(OrganizationMember)
+        .where(OrganizationMember.organization_id == org_id, OrganizationMember.user_id == user_id)
+        .options(joinedload(OrganizationMember.user))
+    )
+    if not member:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
+
+    if member.role == Role.ADMIN and payload.role != "admin":
+        admin_count = db.scalar(
+            select(func.count()).select_from(OrganizationMember).where(
+                OrganizationMember.organization_id == org_id, OrganizationMember.role == Role.ADMIN
+            )
+        )
+        if admin_count <= 1:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot remove last admin")
+
+    member.role = Role(payload.role)
+    db.commit()
+    db.refresh(member)
+
+    return MemberOut(user_id=member.user.id, email=member.user.email, role=member.role.value, joined_at=member.joined_at)
+
+
+@app.delete("/organizations/{org_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_member(
+    org_id: int,
+    user_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    membership = get_user_org_membership(db, user, org_id)
+
+    if user_id != user.id and membership.role != Role.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
+
+    member_to_remove = db.scalar(
+        select(OrganizationMember).where(
+            OrganizationMember.organization_id == org_id, OrganizationMember.user_id == user_id
+        )
+    )
+    if not member_to_remove:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
+
+    if member_to_remove.role == Role.ADMIN:
+        admin_count = db.scalar(
+            select(func.count()).select_from(OrganizationMember).where(
+                OrganizationMember.organization_id == org_id, OrganizationMember.role == Role.ADMIN
+            )
+        )
+        if admin_count <= 1:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot remove last admin")
+
+    db.delete(member_to_remove)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Invites
+# ---------------------------------------------------------------------------
+
+
+@app.post("/organizations/{org_id}/invites", response_model=InviteOut, status_code=status.HTTP_201_CREATED)
+def create_invite(
+    org_id: int,
+    payload: InviteCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> InviteOut:
+    require_org_admin(db, user, org_id)
+
+    token = generate_invite_token()
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=payload.expires_in_hours)
+
+    invite = Invite(
+        organization_id=org_id,
+        token=token,
+        role=Role(payload.role),
+        created_by=user.id,
+        expires_at=expires_at,
+    )
+    db.add(invite)
+    db.commit()
+    db.refresh(invite)
+
+    invite_url = f"{settings.frontend_origin}/invite/{invite.token}"
+
+    return InviteOut(
+        id=invite.id,
+        token=invite.token,
+        role=invite.role.value,
+        created_at=invite.created_at,
+        expires_at=invite.expires_at,
+        used_at=invite.used_at,
+        invite_url=invite_url,
+    )
+
+
+@app.get("/organizations/{org_id}/invites", response_model=list[InviteOut])
+def list_invites(
+    org_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[InviteOut]:
+    require_org_admin(db, user, org_id)
+
+    invites = db.scalars(
+        select(Invite).where(Invite.organization_id == org_id).order_by(Invite.created_at.desc())
+    ).all()
+
+    return [
+        InviteOut(
+            id=inv.id,
+            token=inv.token,
+            role=inv.role.value,
+            created_at=inv.created_at,
+            expires_at=inv.expires_at,
+            used_at=inv.used_at,
+            invite_url=f"{settings.frontend_origin}/invite/{inv.token}",
+        )
+        for inv in invites
+    ]
+
+
+@app.get("/invites/{token}", response_model=InviteInfo)
+def get_invite_info(token: str, db: Session = Depends(get_db)) -> InviteInfo:
+    invite = db.scalar(
+        select(Invite).where(Invite.token == token).options(joinedload(Invite.organization))
+    )
+    if not invite:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite not found")
+
+    if not is_invite_valid(invite):
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Invite expired or already used")
+
+    return InviteInfo(
+        organization_name=invite.organization.name,
+        role=invite.role.value,
+        expires_at=invite.expires_at,
+    )
+
+
+@app.post("/invites/accept", response_model=OrganizationOut)
+def accept_invite(
+    payload: InviteAccept,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> OrganizationOut:
+    invite = db.scalar(
+        select(Invite).where(Invite.token == payload.token).options(joinedload(Invite.organization))
+    )
+    if not invite:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite not found")
+
+    if not is_invite_valid(invite):
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Invite expired or already used")
+
+    existing = db.scalar(
+        select(OrganizationMember).where(
+            OrganizationMember.user_id == user.id,
+            OrganizationMember.organization_id == invite.organization_id,
+        )
+    )
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already a member of this organization")
+
+    membership = OrganizationMember(
+        user_id=user.id,
+        organization_id=invite.organization_id,
+        role=invite.role,
+    )
+    db.add(membership)
+
+    invite.used_at = datetime.now(timezone.utc)
+    invite.used_by = user.id
+
+    db.commit()
+
+    return OrganizationOut(
+        id=invite.organization.id,
+        name=invite.organization.name,
+        created_at=invite.organization.created_at,
+        created_by=invite.organization.created_by,
+        role=membership.role.value,
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,9 +1,15 @@
+import enum
 from datetime import datetime
 
-from sqlalchemy import DateTime, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import DateTime, Enum as SQLEnum, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .database import Base
+
+
+class Role(str, enum.Enum):
+    ADMIN = "admin"
+    VIEWER = "viewer"
 
 
 class User(Base):
@@ -13,3 +19,53 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    memberships: Mapped[list["OrganizationMember"]] = relationship(back_populates="user", cascade="all, delete-orphan")
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+
+    members: Mapped[list["OrganizationMember"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
+    invites: Mapped[list["Invite"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
+    creator: Mapped["User"] = relationship(foreign_keys=[created_by])
+
+
+class OrganizationMember(Base):
+    __tablename__ = "organization_members"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id"), nullable=False)
+    role: Mapped[Role] = mapped_column(SQLEnum(Role), nullable=False)
+    joined_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user: Mapped["User"] = relationship(back_populates="memberships")
+    organization: Mapped["Organization"] = relationship(back_populates="members")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "organization_id", name="uq_user_organization"),
+    )
+
+
+class Invite(Base):
+    __tablename__ = "invites"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id"), nullable=False)
+    token: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    role: Mapped[Role] = mapped_column(SQLEnum(Role), nullable=False)
+    created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    used_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+
+    organization: Mapped["Organization"] = relationship(back_populates="invites")
+    creator: Mapped["User"] = relationship(foreign_keys=[created_by])
+    redeemer: Mapped["User | None"] = relationship(foreign_keys=[used_by])

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -27,3 +27,64 @@ class Token(BaseModel):
 class AuthResponse(BaseModel):
     token: Token
     user: UserOut
+
+
+# Organization schemas
+
+
+class OrganizationCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+
+
+class OrganizationUpdate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+
+
+class OrganizationOut(BaseModel):
+    id: int
+    name: str
+    created_at: datetime
+    created_by: int
+    role: str
+
+
+# Member schemas
+
+
+class MemberOut(BaseModel):
+    user_id: int
+    email: str
+    role: str
+    joined_at: datetime
+
+
+class MemberUpdateRole(BaseModel):
+    role: str = Field(pattern="^(admin|viewer)$")
+
+
+# Invite schemas
+
+
+class InviteCreate(BaseModel):
+    role: str = Field(pattern="^(admin|viewer)$")
+    expires_in_hours: int = Field(default=168, ge=1, le=720)
+
+
+class InviteOut(BaseModel):
+    id: int
+    token: str
+    role: str
+    created_at: datetime
+    expires_at: datetime
+    used_at: datetime | None
+    invite_url: str
+
+
+class InviteInfo(BaseModel):
+    organization_name: str
+    role: str
+    expires_at: datetime
+
+
+class InviteAccept(BaseModel):
+    token: str

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -30,3 +30,14 @@ def decode_token(token: str) -> str | None:
     except JWTError:
         return None
     return payload.get("sub")
+
+
+def generate_invite_token() -> str:
+    import secrets
+
+    return secrets.token_urlsafe(32)
+
+
+def is_invite_valid(invite) -> bool:
+    now = datetime.now(timezone.utc)
+    return invite.expires_at.replace(tzinfo=timezone.utc) > now and invite.used_at is None

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^5.0.2",
@@ -1295,6 +1296,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1571,6 +1585,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1631,6 +1683,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.0.2",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,85 +1,264 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { login, me, signup } from "./api";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Navigate, Route, Routes, useNavigate, useSearchParams } from "react-router-dom";
+import { acceptInvite, listOrganizations, login, me, signup } from "./api";
+import CreateOrgModal from "./components/CreateOrgModal";
+import InviteAcceptPage from "./components/InviteAcceptPage";
+import OrganizationSwitcher from "./components/OrganizationSwitcher";
+import OrgSettingsPage from "./components/OrgSettingsPage";
 
 const TOKEN_KEY = "five-star-token";
+const CURRENT_ORG_KEY = "five-star-current-org";
 const LOGO_SRC = `${import.meta.env.BASE_URL}brand/five-star-logo.svg`;
 
 export default function App() {
-  const [mode, setMode] = useState("signup");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [message, setMessage] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [user, setUser] = useState(null);
   const [token, setToken] = useState(() => localStorage.getItem(TOKEN_KEY) || "");
-  const [isNavOpen, setIsNavOpen] = useState(false);
-  const menuRef = useRef(null);
-  const menuButtonRef = useRef(null);
+  const [user, setUser] = useState(null);
+  const [organizations, setOrganizations] = useState([]);
+  const [currentOrgId, setCurrentOrgId] = useState(() => {
+    const saved = localStorage.getItem(CURRENT_ORG_KEY);
+    return saved ? Number(saved) : null;
+  });
+  const [showCreateOrg, setShowCreateOrg] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const isAuthenticated = useMemo(() => Boolean(token && user), [token, user]);
+  const currentOrg = useMemo(
+    () => organizations.find((o) => o.id === currentOrgId) || organizations[0] || null,
+    [organizations, currentOrgId]
+  );
+
+  const loadOrganizations = useCallback(
+    async (authToken) => {
+      try {
+        const orgs = await listOrganizations(authToken || token);
+        setOrganizations(orgs);
+        if (orgs.length && !orgs.find((o) => o.id === currentOrgId)) {
+          setCurrentOrgId(orgs[0].id);
+          localStorage.setItem(CURRENT_ORG_KEY, String(orgs[0].id));
+        }
+        return orgs;
+      } catch {
+        return [];
+      }
+    },
+    [token, currentOrgId]
+  );
 
   useEffect(() => {
     async function loadUser() {
       if (!token) {
         setUser(null);
+        setOrganizations([]);
         return;
       }
-
       try {
         const currentUser = await me(token);
         setUser(currentUser);
+        await loadOrganizations(token);
       } catch {
         localStorage.removeItem(TOKEN_KEY);
         setToken("");
         setUser(null);
       }
     }
-
     loadUser();
   }, [token]);
 
-  useEffect(() => {
-    function handleDocumentClick(event) {
-      if (!isNavOpen) {
-        return;
-      }
+  function handleOrgChange(orgId) {
+    setCurrentOrgId(orgId);
+    localStorage.setItem(CURRENT_ORG_KEY, String(orgId));
+  }
 
-      const target = event.target;
-      if (menuRef.current?.contains(target) || menuButtonRef.current?.contains(target)) {
-        return;
-      }
+  function handleOrgCreated(org) {
+    setOrganizations((prev) => [...prev, org]);
+    setCurrentOrgId(org.id);
+    localStorage.setItem(CURRENT_ORG_KEY, String(org.id));
+    setShowCreateOrg(false);
+  }
 
-      setIsNavOpen(false);
-    }
+  function logout() {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(CURRENT_ORG_KEY);
+    setToken("");
+    setUser(null);
+    setOrganizations([]);
+    setCurrentOrgId(null);
+    setIsMenuOpen(false);
+  }
 
-    function handleEscape(event) {
-      if (event.key === "Escape") {
-        setIsNavOpen(false);
-      }
-    }
+  return (
+    <div className="layout">
+      <header className="topbar">
+        <img className="topbar-logo" src={LOGO_SRC} alt="five*" />
 
-    document.addEventListener("mousedown", handleDocumentClick);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("mousedown", handleDocumentClick);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [isNavOpen]);
+        <div className="menu-wrap">
+          {isAuthenticated && organizations.length > 0 && (
+            <OrganizationSwitcher
+              organizations={organizations}
+              currentOrgId={currentOrg?.id}
+              onOrgChange={handleOrgChange}
+            />
+          )}
 
-  async function handleSubmit(event) {
-    event.preventDefault();
+          <button
+            type="button"
+            className="hamburger"
+            aria-label="Toggle menu"
+            aria-expanded={isMenuOpen}
+            onClick={() => setIsMenuOpen((v) => !v)}
+          >
+            <span className="hamburger-bar" />
+            <span className="hamburger-bar" />
+            <span className="hamburger-bar" />
+          </button>
+
+          <div className={`menu-panel ${isMenuOpen ? "menu-panel--open" : ""}`}>
+            {isAuthenticated ? (
+              <div className="menu-section">
+                <p className="menu-kicker">Account</p>
+                <p className="menu-email">{user.email}</p>
+                <div className="menu-divider" />
+                <MenuLink to="/dashboard" label="Dashboard" setIsMenuOpen={setIsMenuOpen} />
+                {currentOrg && (
+                  <MenuLink
+                    to={`/org/${currentOrg.id}/settings`}
+                    label="Org Settings"
+                    setIsMenuOpen={setIsMenuOpen}
+                  />
+                )}
+                <button
+                  type="button"
+                  className="menu-item"
+                  onClick={() => {
+                    setShowCreateOrg(true);
+                    setIsMenuOpen(false);
+                  }}
+                >
+                  + New Organization
+                </button>
+                <div className="menu-divider" />
+                <button type="button" className="menu-item" onClick={logout}>
+                  Log out
+                </button>
+              </div>
+            ) : (
+              <div className="menu-section">
+                <p className="menu-note">Sign up or log in to get started.</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <Routes>
+        <Route
+          path="/"
+          element={
+            isAuthenticated ? (
+              <Navigate to="/dashboard" replace />
+            ) : (
+              <AuthPage
+                token={token}
+                setToken={setToken}
+                setUser={setUser}
+                loadOrganizations={loadOrganizations}
+              />
+            )
+          }
+        />
+        <Route
+          path="/dashboard"
+          element={
+            isAuthenticated ? (
+              <Dashboard
+                token={token}
+                user={user}
+                currentOrg={currentOrg}
+                organizations={organizations}
+                onShowCreateOrg={() => setShowCreateOrg(true)}
+              />
+            ) : (
+              <Navigate to="/" replace />
+            )
+          }
+        />
+        <Route
+          path="/org/:id/settings"
+          element={
+            isAuthenticated ? (
+              <OrgSettingsPage token={token} user={user} />
+            ) : (
+              <Navigate to="/" replace />
+            )
+          }
+        />
+        <Route
+          path="/invite/:inviteToken"
+          element={<InviteAcceptPage token={token} isAuthenticated={isAuthenticated} />}
+        />
+      </Routes>
+
+      {showCreateOrg && (
+        <CreateOrgModal
+          token={token}
+          onCreated={handleOrgCreated}
+          onClose={organizations.length > 0 ? () => setShowCreateOrg(false) : undefined}
+        />
+      )}
+    </div>
+  );
+}
+
+function MenuLink({ to, label, setIsMenuOpen }) {
+  const navigate = useNavigate();
+  return (
+    <button
+      type="button"
+      className="menu-item"
+      onClick={() => {
+        setIsMenuOpen(false);
+        navigate(to);
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function AuthPage({ token, setToken, setUser, loadOrganizations }) {
+  const [mode, setMode] = useState("signup");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const pendingInvite = searchParams.get("invite");
+
+  async function handleSubmit(e) {
+    e.preventDefault();
     setMessage("");
     setIsLoading(true);
 
     try {
       const action = mode === "signup" ? signup : login;
       const response = await action(email, password);
-      localStorage.setItem(TOKEN_KEY, response.token.access_token);
-      setToken(response.token.access_token);
+      const accessToken = response.token.access_token;
+      localStorage.setItem(TOKEN_KEY, accessToken);
+      setToken(accessToken);
       setUser(response.user);
-      setMessage(mode === "signup" ? "Account created and signed in." : "Signed in.");
       setPassword("");
-      setIsNavOpen(false);
+
+      if (pendingInvite) {
+        try {
+          await acceptInvite(accessToken, pendingInvite);
+        } catch {
+          // invite may be expired or already used, continue to dashboard
+        }
+        await loadOrganizations(accessToken);
+        navigate("/dashboard", { replace: true });
+      }
     } catch (error) {
       setMessage(error.message || "Something went wrong");
     } finally {
@@ -87,161 +266,114 @@ export default function App() {
     }
   }
 
-  function logout() {
-    localStorage.removeItem(TOKEN_KEY);
-    setToken("");
-    setUser(null);
-    setMessage("Signed out.");
-    setIsNavOpen(false);
-  }
+  return (
+    <div className="auth-card">
+      <div className="auth-card-head">five*</div>
+      <div className="auth-card-body">
+        <h1 className="auth-title">{mode === "signup" ? "Create your account" : "Welcome back"}</h1>
+        <p className="auth-subtitle">
+          {pendingInvite
+            ? "Sign up or log in to accept your invite."
+            : mode === "signup"
+              ? "Start collecting feedback in minutes."
+              : "Log in to your account."}
+        </p>
 
-  function handleModeChange(nextMode) {
-    setMode(nextMode);
-    setMessage("");
-    setIsNavOpen(false);
-  }
+        <div className="tabs">
+          <button
+            type="button"
+            className={`tab ${mode === "signup" ? "tab--active" : ""}`}
+            onClick={() => setMode("signup")}
+          >
+            Sign up
+          </button>
+          <button
+            type="button"
+            className={`tab ${mode === "login" ? "tab--active" : ""}`}
+            onClick={() => setMode("login")}
+          >
+            Log in
+          </button>
+        </div>
 
-  function jumpToAuthCard() {
-    const authCard = document.getElementById("auth-card");
-    if (authCard) {
-      authCard.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-    setIsNavOpen(false);
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <label className="field-label" htmlFor="email">
+            Email
+          </label>
+          <input
+            className="field-input"
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+
+          <label className="field-label" htmlFor="password">
+            Password (8+ chars)
+          </label>
+          <input
+            className="field-input"
+            id="password"
+            type="password"
+            autoComplete={mode === "signup" ? "new-password" : "current-password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            minLength={8}
+            required
+          />
+
+          <button className="btn btn--primary" type="submit" disabled={isLoading}>
+            {isLoading ? "Working..." : mode === "signup" ? "Create account" : "Log in"}
+          </button>
+        </form>
+
+        {message && <p className="message">{message}</p>}
+      </div>
+    </div>
+  );
+}
+
+function Dashboard({ token, user, currentOrg, organizations, onShowCreateOrg }) {
+  const navigate = useNavigate();
+
+  if (!organizations.length) {
+    return (
+      <div className="dashboard-empty">
+        <h2>Welcome to five*</h2>
+        <p>Create your first organization to get started.</p>
+        <button type="button" className="btn btn--primary" onClick={onShowCreateOrg}>
+          Create organization
+        </button>
+      </div>
+    );
   }
 
   return (
-    <main className="layout">
-      <header className="topbar">
-        <img className="topbar-logo" src={LOGO_SRC} alt="five*" />
-        <div className="menu-wrap">
-          <button
-            ref={menuButtonRef}
-            type="button"
-            className="hamburger"
-            aria-label="Toggle navigation menu"
-            aria-haspopup="menu"
-            aria-expanded={isNavOpen}
-            aria-controls="topbar-menu"
-            onClick={() => setIsNavOpen((current) => !current)}
-          >
-            <span className="hamburger-bar" />
-            <span className="hamburger-bar" />
-            <span className="hamburger-bar" />
-          </button>
+    <div className="dashboard">
+      <div className="dashboard-header">
+        <h2 className="dashboard-title">{currentOrg?.name}</h2>
+        <button
+          type="button"
+          className="btn btn--ghost btn--sm"
+          onClick={() => navigate(`/org/${currentOrg?.id}/settings`)}
+        >
+          Org Settings
+        </button>
+      </div>
 
-          <div
-            ref={menuRef}
-            id="topbar-menu"
-            className={`menu-panel ${isNavOpen ? "menu-panel--open" : ""}`}
-            role="menu"
-            aria-label="Account menu"
-          >
-            <div className="menu-section">
-              <button type="button" className="menu-item" onClick={jumpToAuthCard}>
-                Go to auth form
-              </button>
-            </div>
-
-            <div className="menu-divider" />
-
-            <div className="menu-section">
-              {isAuthenticated ? (
-                <>
-                  <p className="menu-kicker">Signed in as</p>
-                  <p className="menu-email">{user.email}</p>
-                  <button type="button" className="menu-item" onClick={logout}>
-                    Log out
-                  </button>
-                </>
-              ) : (
-                <p className="menu-note">
-                  Create your account or sign in from the card below.
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-      </header>
-
-      <section id="auth-card" className="auth-card" aria-label="Authentication">
-        <div className="auth-card-head">Log in or sign up</div>
-
-        <div className="auth-card-body">
-          <h1 className="auth-title">
-            {isAuthenticated ? "You're signed in" : "Welcome to five*"}
-          </h1>
-          <p className="auth-subtitle">
-            {isAuthenticated
-              ? "Your account session is active."
-              : "Use your email and password to create your account or sign in."}
-          </p>
-
-          {isAuthenticated ? (
-            <div className="authed">
-              <p>
-                Logged in as <strong>{user.email}</strong>
-              </p>
-              <button type="button" className="btn btn--primary" onClick={logout}>
-                Log out
-              </button>
-            </div>
-          ) : (
-            <>
-              <div className="tabs" role="tablist" aria-label="Authentication mode">
-                <button
-                  type="button"
-                  className={`tab ${mode === "signup" ? "tab--active" : ""}`}
-                  onClick={() => handleModeChange("signup")}
-                >
-                  Sign up
-                </button>
-                <button
-                  type="button"
-                  className={`tab ${mode === "login" ? "tab--active" : ""}`}
-                  onClick={() => handleModeChange("login")}
-                >
-                  Log in
-                </button>
-              </div>
-
-              <form className="auth-form" onSubmit={handleSubmit}>
-                <label className="field-label" htmlFor="email">
-                  Email
-                </label>
-                <input
-                  className="field-input"
-                  id="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  onChange={(event) => setEmail(event.target.value)}
-                  required
-                />
-
-                <label className="field-label" htmlFor="password">
-                  Password (8+ chars)
-                </label>
-                <input
-                  className="field-input"
-                  id="password"
-                  type="password"
-                  autoComplete={mode === "signup" ? "new-password" : "current-password"}
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  minLength={8}
-                  required
-                />
-
-                <button className="btn btn--primary" type="submit" disabled={isLoading}>
-                  {isLoading ? "Working..." : mode === "signup" ? "Create account" : "Log in"}
-                </button>
-              </form>
-            </>
-          )}
-
-          {message && <p className="message">{message}</p>}
-        </div>
-      </section>
-    </main>
+      <div className="dashboard-card">
+        <p>
+          Logged in as <strong>{user.email}</strong>
+        </p>
+        <p>
+          Role: <strong>{currentOrg?.role}</strong>
+        </p>
+        <p className="dashboard-hint">
+          Your feedback box and dashboard features will appear here.
+        </p>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -9,6 +9,8 @@ async function request(path, options = {}) {
     },
   });
 
+  if (response.status === 204) return null;
+
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {
     const message = payload?.detail || "Request failed";
@@ -17,6 +19,12 @@ async function request(path, options = {}) {
 
   return payload;
 }
+
+function authHeaders(token) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+// Auth
 
 export async function signup(email, password) {
   return request("/auth/signup", {
@@ -34,8 +42,94 @@ export async function login(email, password) {
 
 export async function me(token) {
   return request("/auth/me", {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers: authHeaders(token),
+  });
+}
+
+// Organizations
+
+export async function createOrganization(token, name) {
+  return request("/organizations", {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function listOrganizations(token) {
+  return request("/organizations", {
+    headers: authHeaders(token),
+  });
+}
+
+export async function getOrganization(token, orgId) {
+  return request(`/organizations/${orgId}`, {
+    headers: authHeaders(token),
+  });
+}
+
+export async function updateOrganization(token, orgId, name) {
+  return request(`/organizations/${orgId}`, {
+    method: "PATCH",
+    headers: authHeaders(token),
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function deleteOrganization(token, orgId) {
+  return request(`/organizations/${orgId}`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+}
+
+// Members
+
+export async function listMembers(token, orgId) {
+  return request(`/organizations/${orgId}/members`, {
+    headers: authHeaders(token),
+  });
+}
+
+export async function updateMemberRole(token, orgId, userId, role) {
+  return request(`/organizations/${orgId}/members/${userId}`, {
+    method: "PATCH",
+    headers: authHeaders(token),
+    body: JSON.stringify({ role }),
+  });
+}
+
+export async function removeMember(token, orgId, userId) {
+  return request(`/organizations/${orgId}/members/${userId}`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+}
+
+// Invites
+
+export async function createInvite(token, orgId, role, expiresInHours = 168) {
+  return request(`/organizations/${orgId}/invites`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ role, expires_in_hours: expiresInHours }),
+  });
+}
+
+export async function listInvites(token, orgId) {
+  return request(`/organizations/${orgId}/invites`, {
+    headers: authHeaders(token),
+  });
+}
+
+export async function getInviteInfo(inviteToken) {
+  return request(`/invites/${inviteToken}`);
+}
+
+export async function acceptInvite(authToken, inviteToken) {
+  return request("/invites/accept", {
+    method: "POST",
+    headers: authHeaders(authToken),
+    body: JSON.stringify({ token: inviteToken }),
   });
 }

--- a/frontend/src/components/CreateOrgModal.jsx
+++ b/frontend/src/components/CreateOrgModal.jsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { createOrganization } from "../api";
+
+export default function CreateOrgModal({ token, onCreated, onClose }) {
+  const [name, setName] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError("");
+    setIsLoading(true);
+    try {
+      const org = await createOrganization(token, name);
+      onCreated(org);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal-card" onClick={(e) => e.stopPropagation()}>
+        <h2 className="modal-title">Create an Organization</h2>
+        <p className="modal-subtitle">Name your organization to get started.</p>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <label className="field-label" htmlFor="org-name">
+            Organization name
+          </label>
+          <input
+            className="field-input"
+            id="org-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Acme Corp"
+            minLength={1}
+            maxLength={255}
+            required
+            autoFocus
+          />
+
+          <button className="btn btn--primary" type="submit" disabled={isLoading}>
+            {isLoading ? "Creating..." : "Create organization"}
+          </button>
+        </form>
+
+        {error && <p className="message message--error">{error}</p>}
+
+        {onClose && (
+          <button type="button" className="btn btn--ghost modal-close" onClick={onClose}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/InviteAcceptPage.jsx
+++ b/frontend/src/components/InviteAcceptPage.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { acceptInvite, getInviteInfo } from "../api";
+
+export default function InviteAcceptPage({ token, isAuthenticated }) {
+  const { inviteToken } = useParams();
+  const navigate = useNavigate();
+  const [info, setInfo] = useState(null);
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAccepting, setIsAccepting] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getInviteInfo(inviteToken);
+        setInfo(data);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    load();
+  }, [inviteToken]);
+
+  async function handleAccept() {
+    if (!isAuthenticated) {
+      navigate(`/?invite=${inviteToken}`);
+      return;
+    }
+    setError("");
+    setIsAccepting(true);
+    try {
+      await acceptInvite(token, inviteToken);
+      navigate("/dashboard");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsAccepting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="invite-page">
+        <div className="invite-card">
+          <p>Loading invite...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !info) {
+    return (
+      <div className="invite-page">
+        <div className="invite-card">
+          <h2 className="invite-title">Invalid Invite</h2>
+          <p className="message message--error">{error}</p>
+          <button type="button" className="btn btn--primary" onClick={() => navigate("/")}>
+            Go to home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="invite-page">
+      <div className="invite-card">
+        <h2 className="invite-title">You've been invited!</h2>
+        <p className="invite-detail">
+          Join <strong>{info.organization_name}</strong> as a <strong>{info.role}</strong>
+        </p>
+
+        {error && <p className="message message--error">{error}</p>}
+
+        <button type="button" className="btn btn--primary" onClick={handleAccept} disabled={isAccepting}>
+          {!isAuthenticated ? "Sign up to accept" : isAccepting ? "Joining..." : "Accept invite"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/InviteList.jsx
+++ b/frontend/src/components/InviteList.jsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { createInvite, listInvites } from "../api";
+
+export default function InviteList({ token, orgId, isAdmin }) {
+  const [invites, setInvites] = useState([]);
+  const [newRole, setNewRole] = useState("viewer");
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(null);
+
+  useEffect(() => {
+    if (isAdmin) loadInvites();
+  }, [orgId, isAdmin]);
+
+  async function loadInvites() {
+    try {
+      const data = await listInvites(token, orgId);
+      setInvites(data);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleCreate() {
+    setError("");
+    try {
+      await createInvite(token, orgId, newRole);
+      await loadInvites();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleCopy(url, inviteId) {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(inviteId);
+      setTimeout(() => setCopied(null), 2000);
+    } catch {
+      setError("Failed to copy");
+    }
+  }
+
+  function inviteStatus(inv) {
+    if (inv.used_at) return "used";
+    const now = new Date();
+    if (new Date(inv.expires_at) < now) return "expired";
+    return "active";
+  }
+
+  if (!isAdmin) return null;
+
+  return (
+    <div className="settings-section">
+      <h3 className="settings-heading">Invite Links</h3>
+      {error && <p className="message message--error">{error}</p>}
+
+      <div className="invite-create">
+        <select className="role-select" value={newRole} onChange={(e) => setNewRole(e.target.value)}>
+          <option value="viewer">viewer</option>
+          <option value="admin">admin</option>
+        </select>
+        <button type="button" className="btn btn--primary btn--sm" onClick={handleCreate}>
+          Generate invite link
+        </button>
+      </div>
+
+      {invites.length > 0 && (
+        <table className="members-table">
+          <thead>
+            <tr>
+              <th>Role</th>
+              <th>Status</th>
+              <th>Expires</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {invites.map((inv) => {
+              const st = inviteStatus(inv);
+              return (
+                <tr key={inv.id}>
+                  <td>{inv.role}</td>
+                  <td>
+                    <span className={`invite-status invite-status--${st}`}>{st}</span>
+                  </td>
+                  <td>{new Date(inv.expires_at).toLocaleDateString()}</td>
+                  <td>
+                    {st === "active" && (
+                      <button
+                        type="button"
+                        className="btn btn--ghost btn--sm"
+                        onClick={() => handleCopy(inv.invite_url, inv.id)}
+                      >
+                        {copied === inv.id ? "Copied!" : "Copy link"}
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MemberList.jsx
+++ b/frontend/src/components/MemberList.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { listMembers, updateMemberRole, removeMember } from "../api";
+
+export default function MemberList({ token, orgId, currentUserId, isAdmin }) {
+  const [members, setMembers] = useState([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    loadMembers();
+  }, [orgId]);
+
+  async function loadMembers() {
+    try {
+      const data = await listMembers(token, orgId);
+      setMembers(data);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleRoleChange(userId, newRole) {
+    setError("");
+    try {
+      await updateMemberRole(token, orgId, userId, newRole);
+      await loadMembers();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleRemove(userId) {
+    setError("");
+    const isSelf = userId === currentUserId;
+    const msg = isSelf ? "Leave this organization?" : "Remove this member?";
+    if (!window.confirm(msg)) return;
+    try {
+      await removeMember(token, orgId, userId);
+      if (isSelf) {
+        window.location.reload();
+      } else {
+        await loadMembers();
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="settings-section">
+      <h3 className="settings-heading">Members</h3>
+      {error && <p className="message message--error">{error}</p>}
+
+      <table className="members-table">
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Joined</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {members.map((m) => (
+            <tr key={m.user_id} className={m.user_id === currentUserId ? "members-row--self" : ""}>
+              <td>{m.email}</td>
+              <td>
+                {isAdmin ? (
+                  <select
+                    className="role-select"
+                    value={m.role}
+                    onChange={(e) => handleRoleChange(m.user_id, e.target.value)}
+                  >
+                    <option value="admin">admin</option>
+                    <option value="viewer">viewer</option>
+                  </select>
+                ) : (
+                  m.role
+                )}
+              </td>
+              <td>{new Date(m.joined_at).toLocaleDateString()}</td>
+              <td>
+                {(isAdmin || m.user_id === currentUserId) && (
+                  <button
+                    type="button"
+                    className="btn btn--danger btn--sm"
+                    onClick={() => handleRemove(m.user_id)}
+                  >
+                    {m.user_id === currentUserId ? "Leave" : "Remove"}
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/OrgSettingsPage.jsx
+++ b/frontend/src/components/OrgSettingsPage.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { deleteOrganization, getOrganization, updateOrganization } from "../api";
+import InviteList from "./InviteList";
+import MemberList from "./MemberList";
+
+export default function OrgSettingsPage({ token, user }) {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [org, setOrg] = useState(null);
+  const [editName, setEditName] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [error, setError] = useState("");
+
+  const isAdmin = org?.role === "admin";
+
+  useEffect(() => {
+    loadOrg();
+  }, [id]);
+
+  async function loadOrg() {
+    try {
+      const data = await getOrganization(token, id);
+      setOrg(data);
+      setEditName(data.name);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleRename(e) {
+    e.preventDefault();
+    setError("");
+    try {
+      const updated = await updateOrganization(token, id, editName);
+      setOrg(updated);
+      setIsEditing(false);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm(`Delete "${org.name}"? This cannot be undone.`)) return;
+    try {
+      await deleteOrganization(token, id);
+      navigate("/dashboard");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  if (!org) {
+    return (
+      <div className="settings-page">
+        {error ? <p className="message message--error">{error}</p> : <p>Loading...</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-page">
+      <button type="button" className="btn btn--ghost btn--sm" onClick={() => navigate("/dashboard")}>
+        &larr; Back to dashboard
+      </button>
+
+      <div className="settings-section">
+        <h2 className="settings-title">{org.name}</h2>
+        <p className="settings-meta">
+          Your role: <strong>{org.role}</strong>
+        </p>
+
+        {error && <p className="message message--error">{error}</p>}
+
+        {isAdmin && (
+          <div className="settings-actions">
+            {isEditing ? (
+              <form className="inline-form" onSubmit={handleRename}>
+                <input
+                  className="field-input"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  minLength={1}
+                  maxLength={255}
+                  required
+                />
+                <button type="submit" className="btn btn--primary btn--sm">
+                  Save
+                </button>
+                <button type="button" className="btn btn--ghost btn--sm" onClick={() => setIsEditing(false)}>
+                  Cancel
+                </button>
+              </form>
+            ) : (
+              <button type="button" className="btn btn--ghost btn--sm" onClick={() => setIsEditing(true)}>
+                Rename
+              </button>
+            )}
+            <button type="button" className="btn btn--danger btn--sm" onClick={handleDelete}>
+              Delete organization
+            </button>
+          </div>
+        )}
+      </div>
+
+      <MemberList token={token} orgId={Number(id)} currentUserId={user.id} isAdmin={isAdmin} />
+      <InviteList token={token} orgId={Number(id)} isAdmin={isAdmin} />
+    </div>
+  );
+}

--- a/frontend/src/components/OrganizationSwitcher.jsx
+++ b/frontend/src/components/OrganizationSwitcher.jsx
@@ -1,0 +1,18 @@
+export default function OrganizationSwitcher({ organizations, currentOrgId, onOrgChange }) {
+  if (!organizations.length) return null;
+
+  return (
+    <select
+      className="org-switcher"
+      value={currentOrgId || ""}
+      onChange={(e) => onOrgChange(Number(e.target.value))}
+      aria-label="Switch organization"
+    >
+      {organizations.map((org) => (
+        <option key={org.id} value={org.id}>
+          {org.name} ({org.role})
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles.css";
 
 createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -336,3 +336,310 @@ body {
     font-size: 1.55rem;
   }
 }
+
+/* Organization Switcher */
+
+.org-switcher {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  background: #fafcfd;
+  margin-right: 0.6rem;
+  max-width: 200px;
+  cursor: pointer;
+}
+
+.org-switcher:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+/* Dashboard */
+
+.dashboard {
+  padding: 2rem;
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-title {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 1.5rem;
+}
+
+.dashboard-card {
+  border: 1px solid #d6dfe6;
+  border-radius: 16px;
+  background: var(--color-surface);
+  padding: 1.5rem;
+  box-shadow: 0 4px 12px rgba(45, 27, 66, 0.06);
+}
+
+.dashboard-card p {
+  margin: 0.3rem 0;
+}
+
+.dashboard-hint {
+  margin-top: 1rem !important;
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+.dashboard-empty {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 4rem 2rem;
+  gap: 0.5rem;
+}
+
+.dashboard-empty h2 {
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.dashboard-empty p {
+  color: var(--color-muted);
+  margin: 0 0 1rem;
+}
+
+/* Settings page */
+
+.settings-page {
+  padding: 2rem;
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.settings-section {
+  border: 1px solid #d6dfe6;
+  border-radius: 16px;
+  background: var(--color-surface);
+  padding: 1.5rem;
+}
+
+.settings-title {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 1.4rem;
+}
+
+.settings-heading {
+  margin: 0 0 1rem;
+  color: var(--color-ink);
+  font-size: 1.1rem;
+}
+
+.settings-meta {
+  margin: 0.4rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.inline-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.inline-form .field-input {
+  margin-bottom: 0;
+  width: auto;
+  flex: 1;
+  min-width: 180px;
+}
+
+/* Members table */
+
+.members-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.93rem;
+}
+
+.members-table th {
+  text-align: left;
+  font-weight: 700;
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid #e3eaf0;
+}
+
+.members-table td {
+  padding: 0.6rem;
+  border-bottom: 1px solid #f0f3f6;
+  color: var(--color-text);
+}
+
+.members-row--self {
+  background: #f5f9fc;
+}
+
+.role-select {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.88rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+/* Invite create row */
+
+.invite-create {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.invite-status {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.invite-status--active {
+  background: #e0f7ea;
+  color: #1a7a3a;
+}
+
+.invite-status--used {
+  background: #e8ecf0;
+  color: #5e6770;
+}
+
+.invite-status--expired {
+  background: #fde8e8;
+  color: #b33030;
+}
+
+/* Modal */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(45, 27, 66, 0.35);
+  display: grid;
+  place-items: center;
+  z-index: 50;
+  padding: 1rem;
+}
+
+.modal-card {
+  width: min(460px, 100%);
+  border-radius: 16px;
+  background: var(--color-surface);
+  padding: 2rem;
+  box-shadow: 0 20px 50px rgba(45, 27, 66, 0.2);
+}
+
+.modal-title {
+  margin: 0 0 0.3rem;
+  color: var(--color-ink);
+  font-size: 1.3rem;
+}
+
+.modal-subtitle {
+  margin: 0 0 1.2rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.modal-close {
+  margin-top: 0.7rem;
+  width: 100%;
+  text-align: center;
+}
+
+/* Invite accept page */
+
+.invite-page {
+  display: grid;
+  place-items: center;
+  padding: 4rem 1rem;
+}
+
+.invite-card {
+  width: min(460px, 100%);
+  border: 1px solid #d6dfe6;
+  border-radius: 16px;
+  background: var(--color-surface);
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 12px 30px rgba(45, 27, 66, 0.08);
+}
+
+.invite-title {
+  margin: 0 0 0.5rem;
+  color: var(--color-ink);
+}
+
+.invite-detail {
+  margin: 0 0 1.5rem;
+  color: var(--color-muted);
+  font-size: 1.05rem;
+}
+
+/* Button variants */
+
+.btn--ghost {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-ink);
+}
+
+.btn--ghost:hover {
+  border-color: #9bb8ca;
+  background: #f4f8fb;
+}
+
+.btn--danger {
+  background: #c43030;
+  color: #fff;
+  border: 1px solid transparent;
+}
+
+.btn--danger:hover {
+  background: #a32828;
+}
+
+.btn--sm {
+  padding: 0.45rem 0.75rem;
+  font-size: 0.88rem;
+}
+
+.message--error {
+  color: #c43030;
+}

--- a/reference/plan__org_setup.md
+++ b/reference/plan__org_setup.md
@@ -1,0 +1,409 @@
+# Implementation Plan: Multi-Organization Management with Role-Based Access
+
+## Context
+
+This change implements the complete user workflow shown in the diagram: after creating a personal account and logging in, users can create organizations, invite others via shareable links, and manage team members with role-based permissions (admin/viewer). Users can belong to multiple organizations with different roles in each.
+
+**Current State:**
+- Basic authentication exists (signup, login with JWT tokens)
+- Single `User` model with email and password
+- Simple React frontend with auth forms
+- No organization or team management features
+
+**User Requirements:**
+- Organizations created as separate step after login (not during signup)
+- Two roles: **admin** (can manage org, invite users, assign roles) and **viewer** (read-only access)
+- Shareable invite links (no email system needed initially)
+- Multi-org membership: users can join multiple organizations with different roles per org
+
+---
+
+## Database Schema Changes
+
+### New Models
+
+#### 1. **Role Enum**
+```python
+class Role(str, enum.Enum):
+    ADMIN = "admin"
+    VIEWER = "viewer"
+```
+
+#### 2. **Organization Model**
+- `id` (primary key)
+- `name` (string, required)
+- `created_at` (timestamp)
+- `created_by` (foreign key to users.id)
+- Relationships: `members` (list of OrganizationMember), `invites` (list of Invite), `creator` (User)
+
+#### 3. **OrganizationMember Model** (junction table)
+- `id` (primary key)
+- `user_id` (foreign key to users.id)
+- `organization_id` (foreign key to organizations.id)
+- `role` (Role enum: admin or viewer)
+- `joined_at` (timestamp)
+- **UniqueConstraint** on (user_id, organization_id) - prevents duplicate memberships
+- Relationships: `user` (User), `organization` (Organization)
+
+#### 4. **Invite Model**
+- `id` (primary key)
+- `organization_id` (foreign key to organizations.id)
+- `token` (string, unique, indexed) - cryptographically secure URL-safe token
+- `role` (Role enum: admin or viewer) - role assigned when invite is accepted
+- `created_by` (foreign key to users.id)
+- `created_at` (timestamp)
+- `expires_at` (timestamp) - default 7 days from creation
+- `used_at` (timestamp, nullable) - marked when invite is accepted
+- `used_by` (foreign key to users.id, nullable)
+- Relationships: `organization` (Organization), `creator` (User), `user` (User)
+
+#### 5. **User Model Updates**
+- Add relationship: `memberships` (list of OrganizationMember)
+
+**File:** `/Users/jon/Desktop/workbench/five-star/backend/app/models.py`
+
+---
+
+## Backend Implementation
+
+### 1. Create Dependencies Module
+
+**New File:** `/Users/jon/Desktop/workbench/five-star/backend/app/dependencies.py`
+
+Reusable FastAPI dependencies for auth and authorization:
+
+- `get_current_user(db, credentials)` - Extract user from JWT Bearer token
+- `get_user_org_membership(db, user, org_id)` - Verify user is member of org (raises 404 if not)
+- `require_org_admin(db, user, org_id)` - Verify user is admin of org (raises 403 if not)
+
+These eliminate code duplication and enforce consistent authorization checks across all endpoints.
+
+### 2. Add Invite Utilities
+
+**File:** `/Users/jon/Desktop/workbench/five-star/backend/app/security.py`
+
+Add helper functions:
+- `generate_invite_token()` - Uses `secrets.token_urlsafe(32)` for cryptographically secure tokens
+- `is_invite_valid(invite)` - Check if invite is not expired and not already used
+
+### 3. Create Pydantic Schemas
+
+**File:** `/Users/jon/Desktop/workbench/five-star/backend/app/schemas.py`
+
+Add request/response schemas:
+- `OrganizationCreate`, `OrganizationUpdate`, `OrganizationOut`
+- `MemberOut`, `MemberUpdateRole`
+- `InviteCreate`, `InviteOut`, `InviteAccept`
+- Update `UserOut` to optionally include `organizations: list[OrganizationOut]`
+
+### 4. API Endpoints
+
+**File:** `/Users/jon/Desktop/workbench/five-star/backend/app/main.py`
+
+#### Organization Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/organizations` | Create new organization, creator becomes admin | User |
+| GET | `/organizations` | List user's organizations with their roles | User |
+| GET | `/organizations/{org_id}` | Get organization details | Member |
+| PATCH | `/organizations/{org_id}` | Update organization name | Admin |
+| DELETE | `/organizations/{org_id}` | Delete organization and all related data | Admin |
+
+#### Member Management Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/organizations/{org_id}/members` | List all members with roles | Member |
+| PATCH | `/organizations/{org_id}/members/{user_id}` | Update member's role | Admin |
+| DELETE | `/organizations/{org_id}/members/{user_id}` | Remove member from org | Admin or self |
+
+**Protection:** Prevent removing/demoting the last admin (validate admin count > 1)
+
+#### Invite Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/organizations/{org_id}/invites` | Generate shareable invite link | Admin |
+| GET | `/organizations/{org_id}/invites` | List org's invites | Admin |
+| GET | `/invites/{token}` | Get invite info (for preview page) | Public |
+| POST | `/invites/accept` | Accept invite and join organization | User |
+
+**Invite Flow:**
+1. Admin creates invite with role (admin/viewer) and expiration (default 7 days)
+2. Returns `invite_url` like `https://app.example.com/invite/{token}`
+3. Recipient visits URL, sees org name and role
+4. If not logged in: redirected to signup/login with invite token preserved
+5. Once authenticated: clicks "Accept" to join org
+6. Invite marked as `used_at` (single-use)
+
+#### Update `/auth/me` Endpoint
+
+Add optional query param `include_orgs=true` to return user's organizations in the response.
+
+---
+
+## Frontend Implementation
+
+### 1. Install React Router
+
+```bash
+cd frontend && npm install react-router-dom
+```
+
+### 2. Update API Client
+
+**File:** `/Users/jon/Desktop/workbench/five-star/frontend/src/api.js`
+
+Add API functions for:
+- Organizations: `createOrganization`, `listOrganizations`, `getOrganization`, `updateOrganization`, `deleteOrganization`
+- Members: `listMembers`, `updateMemberRole`, `removeMember`
+- Invites: `createInvite`, `listInvites`, `getInviteInfo`, `acceptInvite`
+
+### 3. Refactor App.jsx with Routing
+
+**File:** `/Users/jon/Desktop/workbench/five-star/frontend/src/App.jsx`
+
+**Major Changes:**
+- Add React Router with routes: `/`, `/dashboard`, `/invite/:token`, `/org/:id/settings`
+- Add state management:
+  - `organizations` - array of user's orgs with roles
+  - `currentOrgId` - selected organization (persisted to localStorage)
+- Load organizations after authentication
+- Post-login flow:
+  - If user has no orgs → show "Create your first organization" modal
+  - If user has orgs → show dashboard with org switcher
+  - Set first org as current by default
+
+### 4. Create New Components
+
+#### **OrganizationSwitcher Component**
+- Dropdown showing user's organizations
+- Displays: "{Org Name} ({role})"
+- Saves selected org to localStorage as `currentOrgId`
+- Shown in nav bar when authenticated
+
+#### **CreateOrgModal Component**
+- Modal with form: organization name input
+- Calls `createOrganization` API
+- Automatically sets new org as current org after creation
+
+#### **InviteAcceptPage Component**
+- Route: `/invite/:token`
+- Fetches invite info (org name, role) via `getInviteInfo`
+- If not authenticated: shows "Sign up to accept" button → redirects to signup with token in URL
+- If authenticated: shows "Accept Invite" button → calls `acceptInvite` → redirects to dashboard
+- Handles expired/invalid invites gracefully
+
+#### **OrgSettingsPage Component**
+- Route: `/org/:id/settings`
+- Only accessible to org members
+- Tabs or sections for:
+  - Organization details (rename, delete)
+  - Members list
+  - Invite management
+
+#### **MemberList Component**
+- Table showing: email, role, joined date
+- Actions (admin only):
+  - Change role dropdown
+  - Remove member button
+- Shows user's own row differently
+- Leave org button for self
+
+#### **InviteList Component**
+- Table showing: role, created date, expiration, status (active/used/expired)
+- Generate new invite button (admin only)
+- Copy invite URL to clipboard button
+- Shows `invite_url` for each active invite
+
+---
+
+## Security Considerations
+
+1. **Invite Token Security:**
+   - Use `secrets.token_urlsafe(32)` for cryptographic randomness (43-character base64url string)
+   - Store as unique indexed column for fast, safe lookup
+   - Single-use: mark `used_at` when accepted
+   - Time-limited: default 7 days, max 30 days
+
+2. **Authorization Enforcement:**
+   - All org endpoints verify user membership via `get_user_org_membership`
+   - Admin-only actions use `require_org_admin` dependency
+   - Prevent last admin removal (check admin count before changes)
+   - Allow self-removal for any member
+
+3. **Database Integrity:**
+   - UniqueConstraint on (user_id, organization_id) prevents duplicate memberships
+   - Cascade deletes: removing org deletes all members and invites
+   - Foreign key constraints ensure referential integrity
+
+4. **Token Validation:**
+   - Check `expires_at > now()` before accepting invite
+   - Check `used_at is None` before accepting invite
+   - Return `410 Gone` for expired/used invites
+
+---
+
+## Migration Strategy
+
+Since the app uses `Base.metadata.create_all()` on startup (no Alembic migrations):
+
+**For Development (Recommended):**
+1. Stop application
+2. Drop database: `docker-compose down -v`
+3. Add new models to `models.py`
+4. Start application: `docker-compose up -d`
+5. Tables created automatically with all relationships
+
+**For Production (if existing users):**
+- Option A: Require users to manually create orgs after migration
+- Option B: Run script to auto-create one org per existing user with user as admin
+
+---
+
+## Implementation Sequence
+
+### Phase 1: Backend Data Layer
+1. Update `/Users/jon/Desktop/workbench/five-star/backend/app/models.py`
+   - Add Role enum
+   - Add Organization, OrganizationMember, Invite models
+   - Add relationships to User
+2. Update `/Users/jon/Desktop/workbench/five-star/backend/app/schemas.py`
+   - Add all request/response schemas
+3. Test: Drop DB and restart to verify table creation
+
+### Phase 2: Backend Dependencies
+1. Create `/Users/jon/Desktop/workbench/five-star/backend/app/dependencies.py`
+   - Add `get_current_user`, `get_user_org_membership`, `require_org_admin`
+2. Update `/Users/jon/Desktop/workbench/five-star/backend/app/security.py`
+   - Add `generate_invite_token()`, `is_invite_valid()`
+
+### Phase 3: Backend Endpoints
+1. Update `/Users/jon/Desktop/workbench/five-star/backend/app/main.py`
+   - Add organization CRUD endpoints (5 endpoints)
+   - Add member management endpoints (3 endpoints)
+   - Add invite endpoints (4 endpoints)
+   - Update `/auth/me` to optionally include organizations
+2. Test: Use curl/Postman to verify each endpoint
+
+### Phase 4: Frontend API Client
+1. Update `/Users/jon/Desktop/workbench/five-star/frontend/src/api.js`
+   - Add 12+ new API functions for orgs, members, invites
+2. Test: Call functions from browser console
+
+### Phase 5: Frontend Routing and Components
+1. Install react-router-dom: `cd frontend && npm install react-router-dom`
+2. Refactor `/Users/jon/Desktop/workbench/five-star/frontend/src/App.jsx`
+   - Add routing
+   - Load organizations after auth
+   - Handle "no orgs" state
+3. Create components:
+   - `OrganizationSwitcher.jsx`
+   - `CreateOrgModal.jsx`
+   - `InviteAcceptPage.jsx`
+   - `OrgSettingsPage.jsx`
+   - `MemberList.jsx`
+   - `InviteList.jsx`
+4. Add CSS for new components
+
+### Phase 6: Testing and Polish
+1. End-to-end test critical workflows:
+   - New user → create org → generate invite
+   - Second user → accept invite → join org
+   - Admin → change member role → verify permissions
+   - User → switch between multiple orgs
+2. Add error handling and user feedback messages
+3. Update README with new features
+
+---
+
+## Critical Files
+
+**Backend:**
+- `/Users/jon/Desktop/workbench/five-star/backend/app/models.py` - Core data models
+- `/Users/jon/Desktop/workbench/five-star/backend/app/schemas.py` - API request/response schemas
+- `/Users/jon/Desktop/workbench/five-star/backend/app/dependencies.py` - Auth/authz dependencies (NEW)
+- `/Users/jon/Desktop/workbench/five-star/backend/app/security.py` - Invite token utilities
+- `/Users/jon/Desktop/workbench/five-star/backend/app/main.py` - API endpoints
+
+**Frontend:**
+- `/Users/jon/Desktop/workbench/five-star/frontend/src/App.jsx` - Main app with routing
+- `/Users/jon/Desktop/workbench/five-star/frontend/src/api.js` - API client
+- `/Users/jon/Desktop/workbench/five-star/frontend/src/components/*` - New UI components (6 files)
+
+---
+
+## Verification
+
+### Backend Verification
+1. Start services: `docker-compose up -d`
+2. Check tables created: `docker-compose exec db psql -U user -d five_star -c "\dt"`
+   - Should see: users, organizations, organization_members, invites
+3. Test organization creation:
+   ```bash
+   # Sign up
+   TOKEN=$(curl -X POST http://localhost:8000/auth/signup \
+     -H "Content-Type: application/json" \
+     -d '{"email":"test@example.com","password":"password123"}' | jq -r '.token.access_token')
+
+   # Create org
+   curl -X POST http://localhost:8000/organizations \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"Test Org"}'
+   ```
+4. Test invite flow:
+   ```bash
+   # Create invite
+   INVITE=$(curl -X POST http://localhost:8000/organizations/1/invites \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"role":"viewer"}' | jq -r '.token')
+
+   # Get invite info (public)
+   curl http://localhost:8000/invites/$INVITE
+
+   # Accept invite (as different user)
+   curl -X POST http://localhost:8000/invites/accept \
+     -H "Authorization: Bearer $NEW_USER_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "{\"token\":\"$INVITE\"}"
+   ```
+
+### Frontend Verification
+1. Navigate to `http://localhost:5173`
+2. **New User Flow:**
+   - Sign up with email/password
+   - After login, see "Create your first organization" modal
+   - Create org → redirected to dashboard
+   - See org switcher in nav bar
+3. **Invite Flow:**
+   - Go to org settings
+   - Generate invite link as admin
+   - Copy invite URL
+   - Open in incognito window
+   - Sign up → accept invite → join org
+4. **Multi-Org Flow:**
+   - Create second organization
+   - Use org switcher to toggle between orgs
+   - Verify different roles displayed per org
+5. **Member Management:**
+   - View members list in org settings
+   - Change member role (admin → viewer)
+   - Remove member
+   - Leave organization
+
+### Edge Cases to Test
+- Prevent last admin removal (should show error)
+- Prevent demoting last admin (should show error)
+- Accept expired invite (should show "Invite expired")
+- Accept already-used invite (should show "Invite already used")
+- Join org you're already a member of (should show error)
+- Delete organization (should cascade delete members and invites)
+
+---
+
+## Summary
+
+This implementation adds complete multi-organization support with role-based access control and shareable invite links. The architecture follows the existing patterns (SQLAlchemy 2.0, FastAPI with Pydantic, React with hooks) and maintains clean separation of concerns with reusable dependencies for authorization. The invite system uses secure tokens and proper expiration handling, while the database schema ensures data integrity with constraints and cascade deletes.


### PR DESCRIPTION
## Summary

Implements complete multi-organization support with role-based access control and shareable invite links, enabling the user workflow from the design diagram.

## User Flow

**Primary business owner:**
1. Creates personal account (signup/login)
2. Creates organization → becomes admin automatically
3. Generates shareable invite links with role assignment
4. Manages members and permissions

**Invited users:**
1. Click invite link → see org preview (name, role)
2. Sign up or log in → automatically join organization
3. Can create their own organizations
4. Can belong to multiple orgs with different roles

## Key Features

### Multi-Organization Support
- Users can create and belong to multiple organizations
- Each user has one role per org (admin or viewer)
- Organization switcher in nav bar shows current org and role
- Users can switch between orgs seamlessly

### Role-Based Access Control
- **Admin**: Full management - invite users, change roles, delete org
- **Viewer**: Read-only access to org resources
- Last admin protection prevents accidental lockout
- Role changes validated before execution

### Shareable Invite System
- Cryptographically secure invite tokens (43-char base64url)
- Time-limited invites (default 7 days, configurable)
- Single-use redemption with automatic tracking
- Invite preview shows org name and role before acceptance
- Copy-to-clipboard for easy sharing

## Technical Implementation

### Backend (FastAPI + SQLAlchemy)

**New Models:**
- `Organization` - org metadata and ownership
- `OrganizationMember` - junction table with role
- `Invite` - shareable tokens with expiration
- `Role` enum - admin, viewer

**New Endpoints (12 total):**
- Organizations: POST/GET/PATCH/DELETE `/organizations`
- Members: GET/PATCH/DELETE `/organizations/{id}/members`
- Invites: POST/GET `/organizations/{id}/invites`, GET/POST `/invites`

**Security Features:**
- Reusable auth dependencies (`get_current_user`, `require_org_admin`)
- Role-based authorization middleware
- Invite token validation (expiration, single-use)
- Last admin protection on role/member changes

### Frontend (React + React Router)

**New Components (6):**
- `OrganizationSwitcher` - dropdown to switch between orgs
- `CreateOrgModal` - org creation flow
- `OrgSettingsPage` - member and invite management
- `MemberList` - member table with role editing
- `InviteList` - invite generation and management
- `InviteAcceptPage` - invite acceptance with auth redirect

**Routing:**
- `/` - Auth page (signup/login)
- `/dashboard` - Main dashboard (current org)
- `/org/:id/settings` - Org settings and management
- `/invite/:token` - Invite acceptance page

**State Management:**
- Organizations loaded after authentication
- Current org persisted to localStorage
- Auto-redirect to org creation if no orgs
- Invite token preserved across signup flow

### Database Schema

```sql
organizations (id, name, created_at, created_by)
organization_members (id, user_id, org_id, role, joined_at)
  - UniqueConstraint(user_id, org_id)
invites (id, org_id, token, role, created_by, expires_at, used_at, used_by)
```

**Cardinality:**
- ✅ org has many users
- ✅ user has one role per org
- ✅ user can have multiple orgs with different roles per org

## Testing

**Backend tested:**
- All 12 endpoints functional
- Edge cases: used invite rejection, last admin protection
- Role changes and member removal

**To test frontend:**
1. Start services: `./start.sh`
2. Open http://localhost:5173
3. Sign up → create org → generate invite
4. Open invite in incognito → sign up → auto-join
5. Test org switcher, member management, role changes

## Files Changed

**Backend:**
- `backend/app/models.py` - Added 3 models + Role enum
- `backend/app/schemas.py` - Added 10 request/response schemas
- `backend/app/dependencies.py` - New auth/authz dependencies
- `backend/app/security.py` - Invite token utilities
- `backend/app/main.py` - 12 new API endpoints

**Frontend:**
- `frontend/src/App.jsx` - Full refactor with routing + org state
- `frontend/src/api.js` - 12 new API functions
- `frontend/src/main.jsx` - Added BrowserRouter
- `frontend/src/styles.css` - Styles for new components
- `frontend/src/components/` - 6 new components

**Other:**
- `reference/plan__org_setup.md` - Implementation plan reference

## Migration Notes

Since the app uses `Base.metadata.create_all()`, new tables are created automatically on startup. For development, drop existing database to get clean schema:

\`\`\`bash
docker exec five-star-postgres psql -U postgres -d five_star -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
\`\`\`

For production with existing users, either require manual org creation or run migration script to auto-create orgs.

## Screenshots

(Add screenshots of dashboard, org settings, invite flow)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)