### PR TITLE
Harden local start/stop scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,12 @@ __pycache__/
 # Node
 node_modules/
 dist/
+frontend/.vite/
 
 # Local dev runtime
 .dev/
 .codex/
+.claude/
 
 # OS
 .DS_Store

--- a/start.sh
+++ b/start.sh
@@ -11,6 +11,8 @@ FRONTEND_LOG="$LOG_DIR/frontend.log"
 BUILD_LOG="$LOG_DIR/build.log"
 POSTGRES_MODE_FILE="$ROOT_DIR/.dev/postgres.mode"
 POSTGRES_CONTAINER_NAME="five-star-postgres"
+BACKEND_PORT=8000
+FRONTEND_PORT=5173
 POSTGRES_PORT="${POSTGRES_PORT:-5433}"
 BACKEND_DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:${POSTGRES_PORT}/five_star"
 RUN_SMOKE_TESTS="${RUN_SMOKE_TESTS:-0}"
@@ -30,12 +32,38 @@ container_running() {
   docker ps --filter "name=^/${POSTGRES_CONTAINER_NAME}$" --format "{{.ID}}" | grep -q .
 }
 
+container_is_compose_managed() {
+  local compose_project
+  compose_project="$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.project" }}' "$POSTGRES_CONTAINER_NAME" 2>/dev/null || true)"
+  [[ -n "$compose_project" ]]
+}
+
 sync_port_from_container() {
   local mapped_port
   mapped_port="$(docker port "$POSTGRES_CONTAINER_NAME" 5432/tcp 2>/dev/null | head -n 1 | sed -E 's/.*:([0-9]+)$/\1/' || true)"
   if [[ -n "$mapped_port" ]]; then
     POSTGRES_PORT="$mapped_port"
     BACKEND_DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:${POSTGRES_PORT}/five_star"
+  fi
+}
+
+port_listeners() {
+  local port="$1"
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 0
+  fi
+  lsof -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | sort -u
+}
+
+assert_port_available() {
+  local port="$1"
+  local service_name="$2"
+  local listeners
+  listeners="$(port_listeners "$port" || true)"
+  if [[ -n "$listeners" ]]; then
+    echo "Port $port is already in use; cannot start $service_name." >&2
+    echo "Run ./stop.sh or free the port, then retry." >&2
+    exit 1
   fi
 }
 
@@ -83,6 +111,10 @@ require_command docker
 
 mkdir -p "$PIDS_DIR" "$LOG_DIR"
 
+STOP_POSTGRES=0 "$ROOT_DIR/stop.sh" >/dev/null 2>&1 || true
+assert_port_available "$BACKEND_PORT" "backend"
+assert_port_available "$FRONTEND_PORT" "frontend"
+
 if ! "$ROOT_DIR/build.sh" >"$BUILD_LOG" 2>&1; then
   echo "Dependency/bootstrap step failed. See $BUILD_LOG" >&2
   exit 1
@@ -93,7 +125,11 @@ if container_exists; then
   if ! container_running; then
     docker start "$POSTGRES_CONTAINER_NAME" >/dev/null
   fi
-  echo "external" >"$POSTGRES_MODE_FILE"
+  if container_is_compose_managed; then
+    echo "compose" >"$POSTGRES_MODE_FILE"
+  else
+    echo "reused" >"$POSTGRES_MODE_FILE"
+  fi
   sync_port_from_container
   echo "Using existing Postgres container: $POSTGRES_CONTAINER_NAME"
 else
@@ -110,32 +146,32 @@ wait_for_postgres || {
 (
   cd "$ROOT_DIR/backend"
   DATABASE_URL="$BACKEND_DATABASE_URL" \
-    exec .venv/bin/uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    exec .venv/bin/uvicorn app.main:app --reload --host 0.0.0.0 --port "$BACKEND_PORT"
 ) >"$BACKEND_LOG" 2>&1 &
 echo "$!" >"$BACKEND_PID_FILE"
 
-wait_for_http "http://127.0.0.1:8000/health" || {
+wait_for_http "http://127.0.0.1:${BACKEND_PORT}/health" || {
   echo "Backend did not become healthy in time. See $BACKEND_LOG" >&2
   exit 1
 }
 
-wait_for_http "http://127.0.0.1:8000/ready" || {
+wait_for_http "http://127.0.0.1:${BACKEND_PORT}/ready" || {
   echo "Backend DB readiness check failed. See $BACKEND_LOG" >&2
   exit 1
 }
 
 if [[ "$RUN_SMOKE_TESTS" == "1" ]]; then
-  API_BASE_URL="http://127.0.0.1:8000" \
+  API_BASE_URL="http://127.0.0.1:${BACKEND_PORT}" \
     "$ROOT_DIR/backend/.venv/bin/python" "$ROOT_DIR/scripts/happy_path_test.py"
 fi
 
 (
   cd "$ROOT_DIR/frontend"
-  exec npm run dev -- --host 0.0.0.0 --port 5173
+  exec npm run dev -- --host 0.0.0.0 --port "$FRONTEND_PORT"
 ) >"$FRONTEND_LOG" 2>&1 &
 echo "$!" >"$FRONTEND_PID_FILE"
 
-wait_for_http "http://127.0.0.1:5173" || {
+wait_for_http "http://127.0.0.1:${FRONTEND_PORT}" || {
   echo "Frontend did not become ready in time. See $FRONTEND_LOG" >&2
   exit 1
 }
@@ -144,9 +180,9 @@ trap - ERR
 
 echo "Startup complete."
 echo "Connectivity checks passed (Postgres, backend, DB readiness, frontend)."
-echo "Frontend: http://localhost:5173"
-echo "Backend:  http://localhost:8000"
+echo "Frontend: http://localhost:${FRONTEND_PORT}"
+echo "Backend:  http://localhost:${BACKEND_PORT}"
 echo "Postgres: localhost:${POSTGRES_PORT}"
 echo "Logs:     $LOG_DIR"
 echo "Stop all: ./stop.sh"
-echo "OPEN THIS URL: http://localhost:5173"
+echo "OPEN THIS URL: http://localhost:${FRONTEND_PORT}"

--- a/stop.sh
+++ b/stop.sh
@@ -7,18 +7,25 @@ BACKEND_PID_FILE="$PIDS_DIR/backend.pid"
 FRONTEND_PID_FILE="$PIDS_DIR/frontend.pid"
 POSTGRES_MODE_FILE="$ROOT_DIR/.dev/postgres.mode"
 POSTGRES_CONTAINER_NAME="five-star-postgres"
+BACKEND_PORT=8000
+FRONTEND_PORT=5173
 POSTGRES_PORT="${POSTGRES_PORT:-5433}"
+STOP_POSTGRES="${STOP_POSTGRES:-1}"
 
-stop_pid_file() {
-  local pid_file="$1"
+container_exists() {
+  docker ps -a --filter "name=^/${POSTGRES_CONTAINER_NAME}$" --format "{{.ID}}" | grep -q .
+}
+
+container_is_compose_managed() {
+  local compose_project
+  compose_project="$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.project" }}' "$POSTGRES_CONTAINER_NAME" 2>/dev/null || true)"
+  [[ -n "$compose_project" ]]
+}
+
+stop_pid() {
+  local pid="$1"
   local service_name="$2"
 
-  if [[ ! -f "$pid_file" ]]; then
-    return 0
-  fi
-
-  local pid
-  pid="$(cat "$pid_file")"
   if [[ -n "$pid" ]] && kill -0 "$pid" >/dev/null 2>&1; then
     kill "$pid" >/dev/null 2>&1 || true
 
@@ -34,31 +41,61 @@ stop_pid_file() {
     fi
     echo "Stopped $service_name (pid $pid)"
   fi
+}
+
+stop_pid_file() {
+  local pid_file="$1"
+  local service_name="$2"
+
+  if [[ ! -f "$pid_file" ]]; then
+    return 0
+  fi
+
+  local pid
+  pid="$(cat "$pid_file")"
+  stop_pid "$pid" "$service_name"
 
   rm -f "$pid_file"
 }
 
+stop_listener_by_pattern() {
+  local port="$1"
+  local service_name="$2"
+  local pattern="$3"
+
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local pid
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    local command
+    command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+    if [[ "$command" == *"$pattern"* ]]; then
+      stop_pid "$pid" "$service_name"
+    fi
+  done < <(lsof -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | sort -u)
+}
+
 stop_pid_file "$FRONTEND_PID_FILE" "frontend"
 stop_pid_file "$BACKEND_PID_FILE" "backend"
+stop_listener_by_pattern "$FRONTEND_PORT" "frontend" "node_modules/.bin/vite"
+stop_listener_by_pattern "$BACKEND_PORT" "backend" "uvicorn app.main:app"
 
 postgres_mode=""
 if [[ -f "$POSTGRES_MODE_FILE" ]]; then
   postgres_mode="$(cat "$POSTGRES_MODE_FILE")"
 fi
 
-if [[ "$postgres_mode" == "compose" ]]; then
-  POSTGRES_PORT="$POSTGRES_PORT" docker compose -f "$ROOT_DIR/docker-compose.yml" down --remove-orphans >/dev/null 2>&1 || true
-elif [[ "$postgres_mode" == "external" ]]; then
-  if docker ps --filter "name=^/${POSTGRES_CONTAINER_NAME}$" --format "{{.ID}}" | grep -q .; then
-    docker stop "$POSTGRES_CONTAINER_NAME" >/dev/null 2>&1 || true
+if [[ "$STOP_POSTGRES" == "1" ]]; then
+  if [[ "$postgres_mode" == "compose" ]]; then
+    POSTGRES_PORT="$POSTGRES_PORT" docker compose -f "$ROOT_DIR/docker-compose.yml" down --remove-orphans >/dev/null 2>&1 || true
+  elif [[ -z "$postgres_mode" ]] && container_exists && container_is_compose_managed; then
+    POSTGRES_PORT="$POSTGRES_PORT" docker compose -f "$ROOT_DIR/docker-compose.yml" down --remove-orphans >/dev/null 2>&1 || true
   fi
-else
-  POSTGRES_PORT="$POSTGRES_PORT" docker compose -f "$ROOT_DIR/docker-compose.yml" down --remove-orphans >/dev/null 2>&1 || true
-  if docker ps --filter "name=^/${POSTGRES_CONTAINER_NAME}$" --format "{{.ID}}" | grep -q .; then
-    docker stop "$POSTGRES_CONTAINER_NAME" >/dev/null 2>&1 || true
-  fi
-fi
 
-rm -f "$POSTGRES_MODE_FILE"
+  rm -f "$POSTGRES_MODE_FILE"
+fi
 
 echo "All services stopped."


### PR DESCRIPTION
## Summary

The original anonymous-feedback work from this branch was already superseded by what is now on `main` (merged in PR #4). This PR has been rebased onto current `main` and narrowed to the remaining follow-up that was still useful: hardening the local run scripts.

### What changed
- make `start.sh` safe to rerun by stopping only app services before startup
- preserve reused Postgres containers instead of shutting them down on app cleanup
- keep compose-managed Postgres teardown working when the stack was started by these scripts
- clean up stale backend/frontend listeners more reliably in `stop.sh`
- ignore local `.claude/` and `frontend/.vite/` noise

### Verification
- `bash -n start.sh stop.sh`
- cold start via `./start.sh`
- rerun `./start.sh` while services were already up
- verified `GET /health`, `GET /ready`, and frontend `200 OK`
- teardown via `./stop.sh` with ports and container cleaned up
