### PR TITLE
Add Fly.io deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "replace-with-your-fly-app-name"
+app = "five-star"
 primary_region = "ord"
 
 [env]


### PR DESCRIPTION
## Summary
- set the Fly app name in fly.toml
- add a GitHub Actions workflow that deploys to Fly on pushes to main
- wire deployment to the FLY_API_TOKEN GitHub secret

## Testing
- python3 parse of fly.toml via tomllib
- ruby parse of .github/workflows/deploy.yml via YAML.load_file
