### PR TITLE
Clean up marketing page (fixes #8, #9, #10, #11)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>five-star</title>
   </head>
   <body>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50" y="76" text-anchor="middle" font-family="'Andale Mono', monospace" font-size="90" fill="#d66a3d">*</text>
+</svg>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -201,6 +201,8 @@ export default function App() {
 }
 
 function PublicHeader({ isAuthenticated }) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
   return (
     <header className="topbar topbar--public">
       <Link className="brand-lockup" to={isAuthenticated ? "/dashboard" : "/"}>
@@ -208,6 +210,7 @@ function PublicHeader({ isAuthenticated }) {
         <span className="brand-tag">Built in Baton Rouge for Baton Rouge businesses</span>
       </Link>
 
+      {/* Desktop nav */}
       <div className="public-nav">
         {isAuthenticated ? (
           <Link className="btn btn--primary btn--sm" to="/dashboard">
@@ -223,6 +226,40 @@ function PublicHeader({ isAuthenticated }) {
             </Link>
           </>
         )}
+      </div>
+
+      {/* Mobile hamburger */}
+      <div className="menu-wrap public-menu-wrap">
+        <button
+          type="button"
+          className="hamburger"
+          aria-label="Toggle menu"
+          aria-expanded={isMenuOpen}
+          onClick={() => setIsMenuOpen((v) => !v)}
+        >
+          <span className="hamburger-bar" />
+          <span className="hamburger-bar" />
+          <span className="hamburger-bar" />
+        </button>
+
+        <div className={`menu-panel ${isMenuOpen ? "menu-panel--open" : ""}`}>
+          <div className="menu-section">
+            {isAuthenticated ? (
+              <Link className="menu-item" to="/dashboard" onClick={() => setIsMenuOpen(false)}>
+                Dashboard
+              </Link>
+            ) : (
+              <>
+                <Link className="menu-item" to="/auth?mode=signup" onClick={() => setIsMenuOpen(false)}>
+                  Get started free
+                </Link>
+                <Link className="menu-item" to="/auth?mode=login" onClick={() => setIsMenuOpen(false)}>
+                  Log in
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -64,6 +64,7 @@ const BENEFITS = [
   "A shareable link customers use to submit feedback privately",
   "Anonymous submissions with optional contact details",
   "An actionable digest instead of a pile of raw comments",
+  "AI helps customers turn their feedback into a public review — ready to post to Google or Yelp",
 ];
 
 export default function MarketingPage() {

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 const STEPS = [
   {
     number: "01",
-    title: "Create your space",
+    title: "Create your organization",
     description:
       "Set up your organization in minutes and give your business a simple place to receive input.",
   },

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -73,12 +73,11 @@ export default function MarketingPage() {
         <div className="marketing-panel marketing-panel--hero">
           <p className="section-kicker">Built in Baton Rouge, for Baton Rouge</p>
           <h1 className="marketing-title">
-            Free feedback tools for Baton Rouge businesses that want to keep getting better.
+            Better feedback for Baton Rouge.
           </h1>
           <p className="marketing-copy">
-            five* is a free service for Baton Rouge business owners who want honest customer
-            feedback, clearer summaries, and practical ways to keep improving the businesses that
-            make this city work.
+            Share a simple feedback link with your customers. Get a clean, actionable digest
+            instead of scattered comments.
           </p>
 
           <div className="marketing-actions">
@@ -93,8 +92,6 @@ export default function MarketingPage() {
           <div className="marketing-pill-row">
             <span className="marketing-pill">Made for Baton Rouge</span>
             <span className="marketing-pill">Free for local businesses</span>
-            <span className="marketing-pill">Simple to share</span>
-            <span className="marketing-pill">Built for improvement</span>
           </div>
         </div>
 
@@ -134,25 +131,13 @@ export default function MarketingPage() {
       </section>
 
       <section className="section-shell digest-section">
-        <div className="digest-section__intro">
-          <div className="section-header digest-section__header">
-            <p className="section-kicker">What&apos;s a digest?</p>
-            <h2 className="section-title">One clear team update built from many customer submissions.</h2>
-            <p className="section-copy">
-              A digest is how five* helps Baton Rouge business owners move from scattered feedback
-              to aligned action. Instead of sorting through every submission one by one, you get a
-              structured, actionable summary of what customers are seeing, what needs attention,
-              and what your team should keep protecting.
-            </p>
-          </div>
-
-          <aside className="digest-callout">
-            <p className="digest-callout__label">Not raw comments</p>
-            <p className="digest-callout__copy">
-              Think of it as a working brief for your business: a digest you can review, modify,
-              and share so your team is focused on the same customer experience priorities.
-            </p>
-          </aside>
+        <div className="section-header">
+          <p className="section-kicker">What&apos;s a digest?</p>
+          <h2 className="section-title">One clear team update built from many customer submissions.</h2>
+          <p className="section-copy">
+            A digest is how five* helps you move from scattered feedback to aligned action.
+            You get a structured summary of what customers are seeing and what needs attention.
+          </p>
         </div>
 
         <div className="digest-flow-grid">
@@ -163,20 +148,6 @@ export default function MarketingPage() {
               <p className="marketing-card-copy">{item.description}</p>
             </article>
           ))}
-        </div>
-
-        <div className="digest-alignment-band">
-          <div>
-            <p className="digest-alignment-band__label">Why it matters</p>
-            <h3 className="digest-alignment-band__title">
-              When the whole team sees the same digest, improvement gets more consistent.
-            </h3>
-          </div>
-          <p className="digest-alignment-band__copy">
-            Owners can use the digest to align staff around what customers want fixed, what should
-            be protected, and how Baton Rouge businesses can keep raising the standard for customer
-            experience.
-          </p>
         </div>
       </section>
 

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -155,12 +155,18 @@ export default function MarketingPage() {
 
       <section className="section-shell">
         <div className="section-header">
-          <p className="section-kicker">Why it exists</p>
-          <h2 className="section-title">Built for the problems Baton Rouge owners actually have.</h2>
+          <p className="section-kicker">Our mission</p>
+          <h2 className="section-title">Bringing Baton Rouge customers and businesses closer together.</h2>
           <p className="section-copy">
-            The five* brand in your establishment tells every customer: this business is listening.
-            That signal protects your reputation, invites honest input, and sets you apart from
-            businesses that never ask.
+            Baton Rouge people want to spend money here — on food, dates, gatherings, and everything
+            that makes this city worth living in. But there&apos;s no real medium for customers to
+            work <em>with</em> businesses. Feedback either never happens, turns into gossip, or ends
+            up as a scathing review. five* changes that relationship.
+          </p>
+          <p className="section-copy" style={{marginTop: "0.75rem"}}>
+            The asterisk mark in an establishment is a symbol of unity — it tells every customer:
+            <em> this business is listening, and we believe in them.</em> We don&apos;t put our
+            mark behind a business we wouldn&apos;t stand behind ourselves.
           </p>
         </div>
 

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -49,9 +49,9 @@ const VALUES = [
       "Most owners know something's off before a bad review hits — they just don't have a system to catch it. five* gives you one, for free.",
   },
   {
-    title: "Customers don't always say it to your face",
+    title: "Frustrated customers vent to you, not about you",
     description:
-      "Private feedback surfaces what people actually think. No awkward confrontations, no filtered responses — just honest input you can act on.",
+      "When customers know you're listening, they bring problems to you privately instead of venting on Google. five* gives the frustrated customer somewhere to go — before they go public.",
   },
   {
     title: "Too many channels, not enough signal",
@@ -157,8 +157,9 @@ export default function MarketingPage() {
           <p className="section-kicker">Why it exists</p>
           <h2 className="section-title">Built for the problems Baton Rouge owners actually have.</h2>
           <p className="section-copy">
-            Not another dashboard to ignore. A simple system that works with how you already run
-            your business.
+            The five* brand in your establishment tells every customer: this business is listening.
+            That signal protects your reputation, invites honest input, and sets you apart from
+            businesses that never ask.
           </p>
         </div>
 

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -4,17 +4,17 @@ const PAIN_POINTS = [
   {
     title: "You don't have time to chase reviews",
     description:
-      "Most owners know something's off before a bad review hits — they just don't have a system to catch it early. five* gives you one, for free.",
+      "Most owners know something's off before a bad review hits. They just don't have a system to catch it early. five* gives you one, for free.",
   },
   {
     title: "Frustrated customers vent to you, not about you",
     description:
-      "When customers know you're listening, they bring problems to you privately instead of venting on Google. five* gives them somewhere to go — before they go public.",
+      "When customers know you're listening, they bring problems to you privately instead of venting on Google. five* gives them somewhere to go before that happens.",
   },
   {
     title: "Too many channels, not enough signal",
     description:
-      "Google, Yelp, Facebook — it's scattered and noisy. five* pulls the signal out so you see what matters without the channel-hopping.",
+      "Google, Yelp, Facebook. It's scattered and noisy. five* pulls the signal out so you see what matters without the channel-hopping.",
   },
 ];
 
@@ -35,7 +35,7 @@ const STEPS = [
     number: "03",
     title: "Turn feedback into next steps",
     description:
-      "five* turns submissions into a digest — a clear summary of patterns, priorities, and actions your team can use.",
+      "five* turns submissions into a clear digest: patterns, priorities, and actions your team can use.",
   },
 ];
 
@@ -61,8 +61,8 @@ const DIGEST_FLOW = [
 ];
 
 const BENEFITS = [
-  "Customers submit feedback privately — not as a public review",
-  "Anonymous or identified — customer's choice",
+  "Customers submit feedback privately, not as a public review",
+  "Anonymous or identified, customer's choice",
   "AI-powered digests that surface what actually matters",
 ];
 
@@ -76,8 +76,8 @@ export default function MarketingPage() {
             Better feedback for Baton Rouge.
           </h1>
           <p className="marketing-copy">
-            Your customers want you to succeed — they just need a way to tell you
-            what&apos;s working and what isn&apos;t. five* gives them that channel,
+            Your customers want you to succeed. They just need a way to tell you
+            what&apos;s working and what isn&apos;t. five* gives them that channel
             and gives you a clear summary of what to do next.
           </p>
 
@@ -115,7 +115,7 @@ export default function MarketingPage() {
           <p className="section-kicker">Sound familiar?</p>
           <h2 className="section-title">The current system is broken.</h2>
           <p className="section-copy">
-            Baton Rouge people want to spend money here — on food, dates, gatherings, and
+            Baton Rouge people want to spend money here: food, dates, gatherings, and
             everything that makes this city work. But there&apos;s no real way for customers
             to work <em>with</em> businesses. Feedback either never happens, turns into gossip,
             or ends up as a bad review.
@@ -154,7 +154,7 @@ export default function MarketingPage() {
           <p className="section-kicker">What&apos;s a digest?</p>
           <h2 className="section-title">One clear summary built from many customer submissions.</h2>
           <p className="section-copy">
-            A digest turns raw feedback into a structured summary — patterns, priorities, and
+            A digest turns raw feedback into a structured summary of patterns, priorities, and
             next steps your team can act on. No more reading every comment one by one.
           </p>
         </div>
@@ -180,8 +180,8 @@ export default function MarketingPage() {
           </p>
           <p className="section-copy" style={{marginTop: "0.75rem"}}>
             We don&apos;t put our mark behind a business we wouldn&apos;t stand behind ourselves.
-            five* exists to bring Baton Rouge customers and businesses closer together — because
-            the best businesses are the ones that never stop listening.
+            five* exists to bring Baton Rouge customers and businesses closer together. The best
+            businesses are the ones that never stop listening.
           </p>
         </div>
       </section>

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -11,7 +11,7 @@ const STEPS = [
     number: "02",
     title: "Customers find you and leave feedback",
     description:
-      "Customers search for your business or scan a QR code to leave feedback in seconds on your public page.",
+      "Customers search for your business or scan a QR code to submit feedback privately in seconds.",
   },
   {
     number: "03",
@@ -61,7 +61,7 @@ const VALUES = [
 ];
 
 const BENEFITS = [
-  "A public feedback link you can share anywhere",
+  "A shareable link customers use to submit feedback privately",
   "Anonymous submissions with optional contact details",
   "An actionable digest instead of a pile of raw comments",
 ];

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -174,7 +174,7 @@ export default function MarketingPage() {
       <section className="marketing-cta-band">
         <div>
           <p className="section-kicker">Ready to start</p>
-          <h2 className="section-title">Give your Baton Rouge customers a way to help you improve.</h2>
+          <h2 className="section-title">Give your customers a way to help you improve.</h2>
           <p className="section-copy">
             Create a free account, share your feedback link, and start learning what your business
             needs next.

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -44,19 +44,19 @@ const DIGEST_FLOW = [
 
 const VALUES = [
   {
-    title: "Free community support",
+    title: "You don't have time to chase reviews",
     description:
-      "five* exists to help local businesses improve and thrive without another subscription getting in the way.",
+      "Most owners know something's off before a bad review hits — they just don't have a system to catch it. five* gives you one, for free.",
   },
   {
-    title: "Honest customer input",
+    title: "Customers don't always say it to your face",
     description:
-      "Customers get a respectful place to share feedback, which helps owners listen better and respond with clarity.",
+      "Private feedback surfaces what people actually think. No awkward confrontations, no filtered responses — just honest input you can act on.",
   },
   {
-    title: "Simple summaries",
+    title: "Too many channels, not enough signal",
     description:
-      "Instead of sorting through scattered comments, you get a clearer picture of what to address first.",
+      "Google, Yelp, Facebook — it's scattered and noisy. We pull the signal out so you see what matters without the channel-hopping.",
   },
 ];
 
@@ -76,8 +76,8 @@ export default function MarketingPage() {
             Better feedback for Baton Rouge.
           </h1>
           <p className="marketing-copy">
-            Customers leave private, constructive feedback in seconds. You get a clean,
-            actionable digest — not a pile of public noise.
+            Customers leave private, constructive feedback in seconds. We surface the critical
+            issues and opportunities — so you're not muddling through reviews across every channel.
           </p>
 
           <div className="marketing-actions">
@@ -155,10 +155,10 @@ export default function MarketingPage() {
       <section className="section-shell">
         <div className="section-header">
           <p className="section-kicker">Why it exists</p>
-          <h2 className="section-title">This is a Baton Rouge service, not a software pitch.</h2>
+          <h2 className="section-title">Built for the problems Baton Rouge owners actually have.</h2>
           <p className="section-copy">
-            five* is here to help Baton Rouge businesses improve their customer experience and
-            contribute to a healthier local business community overall.
+            Not another dashboard to ignore. A simple system that works with how you already run
+            your business.
           </p>
         </div>
 

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -9,9 +9,9 @@ const STEPS = [
   },
   {
     number: "02",
-    title: "Share your feedback link",
+    title: "Customers find you and leave feedback",
     description:
-      "Invite customers to tell you what is working and what needs attention through one clean public page.",
+      "Customers search for your business or scan a QR code to leave feedback in seconds on your public page.",
   },
   {
     number: "03",
@@ -76,8 +76,8 @@ export default function MarketingPage() {
             Better feedback for Baton Rouge.
           </h1>
           <p className="marketing-copy">
-            Share a simple feedback link with your customers. Get a clean, actionable digest
-            instead of scattered comments.
+            Customers find you by search or QR code and leave feedback in seconds. You get a
+            clean, actionable digest instead of scattered comments.
           </p>
 
           <div className="marketing-actions">

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -98,7 +98,7 @@ export default function MarketingPage() {
 
         <aside className="marketing-panel marketing-panel--aside">
           <p className="section-kicker">What owners get</p>
-          <h2 className="marketing-side-title">A lightweight system that helps businesses listen well.</h2>
+          <h2 className="marketing-side-title">A lightweight system that helps businesses hear what matters.</h2>
           <div className="marketing-benefit-list">
             {BENEFITS.map((benefit) => (
               <div className="marketing-benefit" key={benefit}>

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -76,8 +76,8 @@ export default function MarketingPage() {
             Better feedback for Baton Rouge.
           </h1>
           <p className="marketing-copy">
-            Customers find you by search or QR code and leave feedback in seconds. You get a
-            clean, actionable digest instead of scattered comments.
+            Customers leave private, constructive feedback in seconds. You get a clean,
+            actionable digest — not a pile of public noise.
           </p>
 
           <div className="marketing-actions">
@@ -135,8 +135,9 @@ export default function MarketingPage() {
           <p className="section-kicker">What&apos;s a digest?</p>
           <h2 className="section-title">One clear team update built from many customer submissions.</h2>
           <p className="section-copy">
-            A digest is how five* helps you move from scattered feedback to aligned action.
-            You get a structured summary of what customers are seeing and what needs attention.
+            five* collects private, constructive feedback — separate from public reviews.
+            A digest turns those submissions into a structured summary of patterns, priorities,
+            and next steps your team can act on.
           </p>
         </div>
 

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -1,11 +1,29 @@
 import { Link } from "react-router-dom";
 
+const PAIN_POINTS = [
+  {
+    title: "You don't have time to chase reviews",
+    description:
+      "Most owners know something's off before a bad review hits — they just don't have a system to catch it early. five* gives you one, for free.",
+  },
+  {
+    title: "Frustrated customers vent to you, not about you",
+    description:
+      "When customers know you're listening, they bring problems to you privately instead of venting on Google. five* gives them somewhere to go — before they go public.",
+  },
+  {
+    title: "Too many channels, not enough signal",
+    description:
+      "Google, Yelp, Facebook — it's scattered and noisy. five* pulls the signal out so you see what matters without the channel-hopping.",
+  },
+];
+
 const STEPS = [
   {
     number: "01",
     title: "Create your organization",
     description:
-      "Set up your organization in minutes and give your business a simple place to receive input.",
+      "Set up your business on five* in minutes. You get a simple page where customers can leave private feedback.",
   },
   {
     number: "02",
@@ -17,7 +35,7 @@ const STEPS = [
     number: "03",
     title: "Turn feedback into next steps",
     description:
-      "Gather customer input and turn it into a digest your team can use to improve customer experience.",
+      "five* turns submissions into a digest — a clear summary of patterns, priorities, and actions your team can use.",
   },
 ];
 
@@ -38,33 +56,14 @@ const DIGEST_FLOW = [
     number: "03",
     title: "Review, refine, and share",
     description:
-      "You can review and modify the digest, then share it with your team by link so everyone stays aligned on what to improve and uphold.",
-  },
-];
-
-const VALUES = [
-  {
-    title: "You don't have time to chase reviews",
-    description:
-      "Most owners know something's off before a bad review hits — they just don't have a system to catch it. five* gives you one, for free.",
-  },
-  {
-    title: "Frustrated customers vent to you, not about you",
-    description:
-      "When customers know you're listening, they bring problems to you privately instead of venting on Google. five* gives the frustrated customer somewhere to go — before they go public.",
-  },
-  {
-    title: "Too many channels, not enough signal",
-    description:
-      "Google, Yelp, Facebook — it's scattered and noisy. We pull the signal out so you see what matters without the channel-hopping.",
+      "Review and modify the digest, then share it with your team so everyone is aligned on what to improve and what to protect.",
   },
 ];
 
 const BENEFITS = [
-  "A shareable link customers use to submit feedback privately",
-  "Anonymous submissions with optional contact details",
-  "An actionable digest instead of a pile of raw comments",
-  "AI helps customers turn their feedback into a public review — ready to post to Google or Yelp",
+  "Customers submit feedback privately — not as a public review",
+  "Anonymous or identified — customer's choice",
+  "AI-powered digests that surface what actually matters",
 ];
 
 export default function MarketingPage() {
@@ -77,8 +76,9 @@ export default function MarketingPage() {
             Better feedback for Baton Rouge.
           </h1>
           <p className="marketing-copy">
-            Customers leave private, constructive feedback in seconds. We surface the critical
-            issues and opportunities — so you're not muddling through reviews across every channel.
+            Your customers want you to succeed — they just need a way to tell you
+            what&apos;s working and what isn&apos;t. five* gives them that channel,
+            and gives you a clear summary of what to do next.
           </p>
 
           <div className="marketing-actions">
@@ -112,12 +112,30 @@ export default function MarketingPage() {
 
       <section className="section-shell">
         <div className="section-header">
-          <p className="section-kicker">How it works</p>
-          <h2 className="section-title">A simple flow for listening, learning, and improving.</h2>
+          <p className="section-kicker">Sound familiar?</p>
+          <h2 className="section-title">The current system is broken.</h2>
           <p className="section-copy">
-            The goal is not to overwhelm Baton Rouge owners. It is to make customer feedback easier
-            to collect and easier to use.
+            Baton Rouge people want to spend money here — on food, dates, gatherings, and
+            everything that makes this city work. But there&apos;s no real way for customers
+            to work <em>with</em> businesses. Feedback either never happens, turns into gossip,
+            or ends up as a bad review.
           </p>
+        </div>
+
+        <div className="marketing-grid">
+          {PAIN_POINTS.map((point) => (
+            <article className="marketing-card" key={point.title}>
+              <h3 className="marketing-card-title">{point.title}</h3>
+              <p className="marketing-card-copy">{point.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section-shell">
+        <div className="section-header">
+          <p className="section-kicker">How it works</p>
+          <h2 className="section-title">Simple for you. Simple for your customers.</h2>
         </div>
 
         <div className="marketing-grid">
@@ -134,11 +152,10 @@ export default function MarketingPage() {
       <section className="section-shell digest-section">
         <div className="section-header">
           <p className="section-kicker">What&apos;s a digest?</p>
-          <h2 className="section-title">One clear team update built from many customer submissions.</h2>
+          <h2 className="section-title">One clear summary built from many customer submissions.</h2>
           <p className="section-copy">
-            five* collects private, constructive feedback — separate from public reviews.
-            A digest turns those submissions into a structured summary of patterns, priorities,
-            and next steps your team can act on.
+            A digest turns raw feedback into a structured summary — patterns, priorities, and
+            next steps your team can act on. No more reading every comment one by one.
           </p>
         </div>
 
@@ -155,28 +172,17 @@ export default function MarketingPage() {
 
       <section className="section-shell">
         <div className="section-header">
-          <p className="section-kicker">Our mission</p>
-          <h2 className="section-title">Bringing Baton Rouge customers and businesses closer together.</h2>
+          <p className="section-kicker">Why five*</p>
+          <h2 className="section-title">The asterisk means this business is listening.</h2>
           <p className="section-copy">
-            Baton Rouge people want to spend money here — on food, dates, gatherings, and everything
-            that makes this city worth living in. But there&apos;s no real medium for customers to
-            work <em>with</em> businesses. Feedback either never happens, turns into gossip, or ends
-            up as a scathing review. five* changes that relationship.
+            The five* mark in an establishment is a symbol of unity between a business and its
+            community. It tells every customer: <em>we care, and we want to hear from you.</em>
           </p>
           <p className="section-copy" style={{marginTop: "0.75rem"}}>
-            The asterisk mark in an establishment is a symbol of unity — it tells every customer:
-            <em> this business is listening, and we believe in them.</em> We don&apos;t put our
-            mark behind a business we wouldn&apos;t stand behind ourselves.
+            We don&apos;t put our mark behind a business we wouldn&apos;t stand behind ourselves.
+            five* exists to bring Baton Rouge customers and businesses closer together — because
+            the best businesses are the ones that never stop listening.
           </p>
-        </div>
-
-        <div className="marketing-grid">
-          {VALUES.map((value) => (
-            <article className="marketing-card" key={value.title}>
-              <h3 className="marketing-card-title">{value.title}</h3>
-              <p className="marketing-card-copy">{value.description}</p>
-            </article>
-          ))}
         </div>
       </section>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -107,10 +107,7 @@ select {
 }
 
 .brand-tag {
-  max-width: 260px;
-  color: var(--color-muted);
-  font-size: 0.9rem;
-  line-height: 1.4;
+  display: none; /* Already in hero, don't repeat in header */
 }
 
 .public-nav,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -812,14 +812,16 @@ select {
     font-size: 1.65rem;
   }
 
-  .marketing-actions,
+  .marketing-actions {
+    display: none; /* header already has Log in + Get started on mobile */
+  }
+
   .public-nav {
     width: 100%;
     flex-direction: column;
     align-items: stretch;
   }
 
-  .marketing-actions .btn,
   .public-nav .btn,
   .marketing-cta-band .btn {
     width: 100%;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -812,19 +812,18 @@ select {
     font-size: 1.65rem;
   }
 
-  .marketing-actions {
-    display: none; /* header already has Log in + Get started on mobile */
-  }
-
-  .public-nav {
-    width: 100%;
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .public-nav .btn,
+  .marketing-actions,
   .marketing-cta-band .btn {
     width: 100%;
+  }
+
+  .marketing-actions {
+    flex-direction: column;
+  }
+
+  /* Hide header nav on marketing page — hero already has the CTAs */
+  .topbar--public .public-nav {
+    display: none;
   }
 
   .marketing-cta-band {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -131,6 +131,11 @@ select {
   align-items: center;
 }
 
+/* Public header hamburger — hidden on desktop, shown on mobile */
+.public-menu-wrap {
+  display: none;
+}
+
 .hamburger {
   width: 42px;
   height: 42px;
@@ -821,9 +826,13 @@ select {
     flex-direction: column;
   }
 
-  /* Hide header nav on marketing page — hero already has the CTAs */
+  /* On mobile: hide desktop nav, show hamburger instead */
   .topbar--public .public-nav {
     display: none;
+  }
+
+  .public-menu-wrap {
+    display: flex;
   }
 
   .marketing-cta-band {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -708,43 +708,6 @@ select {
   gap: 1.25rem;
 }
 
-.digest-section__intro {
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
-  gap: 1rem;
-  align-items: stretch;
-}
-
-.digest-section__header {
-  margin-bottom: 0;
-}
-
-.digest-callout {
-  display: grid;
-  align-content: start;
-  gap: 0.8rem;
-  padding: 1.35rem;
-  border-radius: 22px;
-  border: 1px solid rgba(24, 57, 43, 0.08);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(248, 240, 229, 0.9) 100%);
-}
-
-.digest-callout__label,
-.digest-alignment-band__label {
-  margin: 0;
-  color: var(--color-primary);
-  font-size: 0.82rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.digest-callout__copy,
-.digest-alignment-band__copy {
-  margin: 0;
-  line-height: 1.75;
-  color: var(--color-text);
-}
 
 .digest-flow-grid {
   display: grid;
@@ -756,28 +719,6 @@ select {
   background: rgba(255, 255, 255, 0.9);
 }
 
-.digest-alignment-band {
-  display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
-  gap: 1rem 1.5rem;
-  align-items: center;
-  padding: 1.4rem 1.5rem;
-  border-radius: 24px;
-  background: linear-gradient(135deg, rgba(24, 57, 43, 0.96) 0%, rgba(41, 75, 58, 0.96) 100%);
-}
-
-.digest-alignment-band__title {
-  margin: 0.35rem 0 0;
-  font-family: var(--font-serif);
-  font-size: clamp(1.7rem, 3vw, 2.35rem);
-  line-height: 1.08;
-  letter-spacing: -0.03em;
-  color: #f8f2e8;
-}
-
-.digest-alignment-band__copy {
-  color: rgba(248, 242, 232, 0.9);
-}
 
 .marketing-cta-band {
   padding: clamp(1.7rem, 4vw, 2.5rem);
@@ -801,9 +742,7 @@ select {
 @media (max-width: 960px) {
   .auth-shell,
   .marketing-hero,
-  .digest-section__intro,
   .digest-flow-grid,
-  .digest-alignment-band,
   .marketing-grid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- **#10** — Shorten hero headline to "Better feedback for Baton Rouge." and tighten copy
- **#8** — Reduce hero pills from 4 to 2 (keep "Made for Baton Rouge" and "Free for local businesses")
- **#9** — Simplify "What's a Digest?" section: remove callout aside and alignment band, keep header + 3 flow cards
- **#11** — Add asterisk favicon (SVG) matching the five* logo brand color

## Test plan
- [ ] Verify hero has shorter headline and only 2 pills
- [ ] Verify "What's a Digest?" section is cleaner (no callout box, no dark band)
- [ ] Verify favicon shows as orange asterisk in browser tab
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)