### PR TITLE
Add public search (issue #17)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -210,26 +210,30 @@ function PublicHeader({ isAuthenticated }) {
         <span className="brand-tag">Built in Baton Rouge for Baton Rouge businesses</span>
       </Link>
 
-      {/* Desktop nav */}
-      <div className="public-nav">
-        {isAuthenticated ? (
-          <Link className="btn btn--primary btn--sm" to="/dashboard">
-            Dashboard
-          </Link>
-        ) : (
-          <>
-            <Link className="btn btn--ghost btn--sm" to="/auth?mode=login">
-              Log in
-            </Link>
-            <Link className="btn btn--primary btn--sm" to="/auth?mode=signup">
-              Get started free
-            </Link>
-          </>
-        )}
-      </div>
+      {/* Right side — search always visible, nav toggles per breakpoint */}
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <TopbarSearch />
 
-      {/* Mobile hamburger */}
-      <div className="menu-wrap public-menu-wrap">
+        {/* Desktop nav */}
+        <div className="public-nav">
+          {isAuthenticated ? (
+            <Link className="btn btn--primary btn--sm" to="/dashboard">
+              Dashboard
+            </Link>
+          ) : (
+            <>
+              <Link className="btn btn--ghost btn--sm" to="/auth?mode=login">
+                Log in
+              </Link>
+              <Link className="btn btn--primary btn--sm" to="/auth?mode=signup">
+                Get started free
+              </Link>
+            </>
+          )}
+        </div>
+
+        {/* Mobile hamburger */}
+        <div className="menu-wrap public-menu-wrap">
         <button
           type="button"
           className="hamburger"
@@ -260,6 +264,7 @@ function PublicHeader({ isAuthenticated }) {
             )}
           </div>
         </div>
+      </div>
       </div>
     </header>
   );

--- a/frontend/src/components/TopbarSearch.jsx
+++ b/frontend/src/components/TopbarSearch.jsx
@@ -2,7 +2,20 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { searchOrganizations } from "../api";
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(() => window.matchMedia("(max-width: 480px)").matches);
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 480px)");
+    const handler = (e) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return isMobile;
+}
+
 export default function TopbarSearch() {
+  const isMobile = useIsMobile();
+  const [isExpanded, setIsExpanded] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -10,33 +23,57 @@ export default function TopbarSearch() {
   const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef(null);
   const containerRef = useRef(null);
+  const panelRef = useRef(null);
   const debounceRef = useRef(null);
   const navigate = useNavigate();
 
+  function expand() {
+    setIsExpanded(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  function collapse() {
+    setIsExpanded(false);
+    setQuery("");
+    setResults([]);
+    setIsOpen(false);
+    setActiveIndex(-1);
+  }
+
+  // Desktop: click-outside closes the inline input
   useEffect(() => {
+    if (isMobile || !isExpanded) return;
     function handleClickOutside(e) {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
-        setIsOpen(false);
-        setActiveIndex(-1);
+        collapse();
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  }, [isMobile, isExpanded]);
+
+  // Mobile: click-outside closes the pill panel
+  useEffect(() => {
+    if (!isMobile || !isExpanded) return;
+    function handleClickOutside(e) {
+      if (panelRef.current && !panelRef.current.contains(e.target)) {
+        collapse();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isMobile, isExpanded]);
 
   function handleChange(e) {
     const val = e.target.value;
     setQuery(val);
     setActiveIndex(-1);
-
     if (debounceRef.current) clearTimeout(debounceRef.current);
-
     if (!val || val.trim().length < 2) {
       setResults([]);
       setIsOpen(false);
       return;
     }
-
     debounceRef.current = setTimeout(async () => {
       setIsSearching(true);
       try {
@@ -52,13 +89,12 @@ export default function TopbarSearch() {
   }
 
   function handleSelect(org) {
-    setQuery("");
-    setResults([]);
-    setIsOpen(false);
+    collapse();
     navigate(`/feedback/${org.feedback_token}`);
   }
 
   function handleKeyDown(e) {
+    if (e.key === "Escape") { collapse(); return; }
     if (!isOpen || !results.length) {
       if (e.key === "Enter" && query.trim().length >= 2) {
         navigate(`/search?q=${encodeURIComponent(query)}`);
@@ -73,108 +109,226 @@ export default function TopbarSearch() {
       setActiveIndex((i) => Math.max(i - 1, -1));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      if (activeIndex >= 0) {
-        handleSelect(results[activeIndex]);
-      } else {
-        navigate(`/search?q=${encodeURIComponent(query)}`);
-      }
-    } else if (e.key === "Escape") {
-      setIsOpen(false);
-      setActiveIndex(-1);
-      inputRef.current?.blur();
+      if (activeIndex >= 0) handleSelect(results[activeIndex]);
+      else navigate(`/search?q=${encodeURIComponent(query)}`);
     }
   }
 
-  return (
+  const resultList = isOpen && results.length > 0 && (
     <div
-      ref={containerRef}
-      style={{ position: "relative", width: 220 }}
+      style={{
+        position: "absolute",
+        top: "calc(100% + 6px)",
+        right: 0,
+        width: isMobile ? "100%" : 260,
+        border: "1px solid #d6dfe6",
+        borderRadius: "12px",
+        background: "white",
+        boxShadow: "0 4px 12px rgba(45, 27, 66, 0.1)",
+        zIndex: 50,
+        overflow: "hidden",
+      }}
+      role="listbox"
     >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          border: "1px solid var(--color-border)",
-          borderRadius: "10px",
-          background: "#fafcfd",
-          padding: "0 0.75rem",
-          gap: "0.4rem",
-          transition: "border-color 150ms ease, box-shadow 150ms ease",
-        }}
-        className="topbar-search-wrap"
-      >
-        <span style={{ color: "#8a9aaa", fontSize: "0.9rem", flexShrink: 0 }}>⌕</span>
-        <input
-          ref={inputRef}
-          type="text"
-          value={query}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          onFocus={() => results.length > 0 && setIsOpen(true)}
-          placeholder="Search organizations…"
+      {results.map((org, idx) => (
+        <button
+          key={org.feedback_token}
+          type="button"
+          role="option"
+          aria-selected={idx === activeIndex}
+          onClick={() => handleSelect(org)}
+          onMouseEnter={() => setActiveIndex(idx)}
           style={{
-            flex: 1,
+            width: "100%",
+            textAlign: "left",
+            padding: "0.65rem 0.9rem",
             border: "none",
-            background: "transparent",
-            outline: "none",
+            borderBottom: idx < results.length - 1 ? "1px solid #f0f3f6" : "none",
+            background: idx === activeIndex ? "#f4f8fb" : "white",
+            cursor: "pointer",
             fontSize: "0.9rem",
             color: "var(--color-ink)",
-            padding: "0.55rem 0",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
           }}
-          aria-label="Search organizations"
-          aria-autocomplete="list"
-          aria-expanded={isOpen}
-        />
-        {isSearching && (
-          <span style={{ color: "#aab4be", fontSize: "0.75rem", flexShrink: 0 }}>…</span>
-        )}
-      </div>
-
-      {isOpen && results.length > 0 && (
-        <div
-          style={{
-            position: "absolute",
-            top: "calc(100% + 6px)",
-            left: 0,
-            right: 0,
-            border: "1px solid #d6dfe6",
-            borderRadius: "12px",
-            background: "white",
-            boxShadow: "0 4px 12px rgba(45, 27, 66, 0.1)",
-            zIndex: 50,
-            overflow: "hidden",
-          }}
-          role="listbox"
         >
-          {results.map((org, idx) => (
-            <button
-              key={org.feedback_token}
-              type="button"
-              role="option"
-              aria-selected={idx === activeIndex}
-              onClick={() => handleSelect(org)}
-              onMouseEnter={() => setActiveIndex(idx)}
+          <span>{org.name}</span>
+          <span style={{ color: "#aab4be", fontSize: "0.8rem" }}>→</span>
+        </button>
+      ))}
+    </div>
+  );
+
+  // ── Desktop: inline expansion ──────────────────────────────────────────────
+  if (!isMobile) {
+    return (
+      <div ref={containerRef} style={{ position: "relative" }}>
+        {isExpanded ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              border: "1px solid var(--color-border)",
+              borderRadius: "12px",
+              background: "rgba(255, 253, 247, 0.92)",
+              padding: "0 0.75rem",
+              gap: "0.4rem",
+              width: 220,
+            }}
+            className="topbar-search-wrap"
+          >
+            <span style={{ color: "#8a9aaa", fontSize: "1.2rem", flexShrink: 0 }}>⌕</span>
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              placeholder="Search organizations…"
               style={{
-                width: "100%",
-                textAlign: "left",
-                padding: "0.65rem 0.9rem",
+                flex: 1,
                 border: "none",
-                borderBottom: idx < results.length - 1 ? "1px solid #f0f3f6" : "none",
-                background: idx === activeIndex ? "#f4f8fb" : "white",
-                cursor: "pointer",
+                background: "transparent",
+                outline: "none",
                 fontSize: "0.9rem",
                 color: "var(--color-ink)",
+                padding: "0.55rem 0",
+              }}
+              aria-label="Search organizations"
+              aria-autocomplete="list"
+              aria-expanded={isOpen}
+            />
+            {isSearching && (
+              <span style={{ color: "#aab4be", fontSize: "0.75rem", flexShrink: 0 }}>…</span>
+            )}
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="hamburger"
+            aria-label="Search organizations"
+            onClick={expand}
+          >
+            <span style={{ fontSize: "1.6rem", lineHeight: 1, color: "var(--color-ink)" }}>⌕</span>
+          </button>
+        )}
+        {resultList}
+      </div>
+    );
+  }
+
+  // ── Mobile: floating pill ──────────────────────────────────────────────────
+  return (
+    <>
+      <button
+        type="button"
+        className="hamburger"
+        aria-label="Search organizations"
+        onClick={isExpanded ? collapse : expand}
+      >
+        <span style={{ fontSize: "1.6rem", lineHeight: 1, color: "var(--color-ink)" }}>⌕</span>
+      </button>
+
+      {isExpanded && (
+        <>
+          <div
+            style={{ position: "fixed", inset: 0, zIndex: 39 }}
+            onClick={collapse}
+          />
+          <div
+            ref={panelRef}
+            className="topbar-search-panel"
+            style={{
+              position: "fixed",
+              left: "50%",
+              transform: "translateX(-50%)",
+              width: "min(520px, calc(100vw - 2rem))",
+              zIndex: 40,
+            }}
+          >
+            <div
+              style={{
                 display: "flex",
                 alignItems: "center",
-                justifyContent: "space-between",
+                background: "white",
+                border: "1px solid var(--color-border)",
+                borderRadius: results.length > 0 && isOpen ? "16px 16px 0 0" : "16px",
+                padding: "0 1rem",
+                gap: "0.5rem",
+                boxShadow: "0 4px 20px rgba(45, 27, 66, 0.12)",
               }}
             >
-              <span>{org.name}</span>
-              <span style={{ color: "#aab4be", fontSize: "0.8rem" }}>→</span>
-            </button>
-          ))}
-        </div>
+              <span style={{ color: "#8a9aaa", fontSize: "1.2rem", flexShrink: 0 }}>⌕</span>
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                placeholder="Search organizations…"
+                style={{
+                  flex: 1,
+                  border: "none",
+                  background: "transparent",
+                  outline: "none",
+                  fontSize: "1rem",
+                  color: "var(--color-ink)",
+                  padding: "0.85rem 0",
+                }}
+                aria-label="Search organizations"
+                aria-autocomplete="list"
+                aria-expanded={isOpen}
+              />
+              {isSearching && (
+                <span style={{ color: "#aab4be", fontSize: "0.8rem", flexShrink: 0 }}>…</span>
+              )}
+            </div>
+
+            {isOpen && results.length > 0 && (
+              <div
+                style={{
+                  border: "1px solid var(--color-border)",
+                  borderTop: "none",
+                  borderRadius: "0 0 16px 16px",
+                  background: "white",
+                  boxShadow: "0 8px 20px rgba(45, 27, 66, 0.1)",
+                  overflow: "hidden",
+                }}
+                role="listbox"
+              >
+                {results.map((org, idx) => (
+                  <button
+                    key={org.feedback_token}
+                    type="button"
+                    role="option"
+                    aria-selected={idx === activeIndex}
+                    onClick={() => handleSelect(org)}
+                    onMouseEnter={() => setActiveIndex(idx)}
+                    style={{
+                      width: "100%",
+                      textAlign: "left",
+                      padding: "0.75rem 1rem",
+                      border: "none",
+                      borderBottom: idx < results.length - 1 ? "1px solid #f0f3f6" : "none",
+                      background: idx === activeIndex ? "#f4f8fb" : "white",
+                      cursor: "pointer",
+                      fontSize: "0.95rem",
+                      color: "var(--color-ink)",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                    }}
+                  >
+                    <span>{org.name}</span>
+                    <span style={{ color: "#aab4be", fontSize: "0.85rem" }}>→</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
       )}
-    </div>
+    </>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1302,6 +1302,17 @@ select {
   font-size: 0.875rem;
 }
 
+/* Topbar search panel */
+.topbar-search-panel {
+  top: calc(84px + 8px);
+}
+
+@media (max-width: 760px) {
+  .topbar-search-panel {
+    top: calc(72px + 8px);
+  }
+}
+
 /* Search page */
 .search-page {
   display: flex;


### PR DESCRIPTION
## Summary

- Search is now available to all visitors, not just logged-in users — fixes #17
- Search icon button appears in the topbar on every page (public and authenticated headers)
- **Desktop/tablet (>480px):** clicking the icon expands the search input inline within the topbar
- **Mobile (≤480px):** clicking opens a floating pill below the topbar (like the menu panel), keeping the topbar clean
- Auto-focuses on open, collapses on Escape or click outside, live results with keyboard nav

## Test plan

- [ ] Visit the marketing page while logged out — search icon visible in topbar
- [ ] Desktop: click search icon → expands inline, type → results appear, Escape → collapses
- [ ] Mobile (375px): click search icon → pill appears below topbar with gap, type → results appear
- [ ] ~487px width: inline expansion (not pill)
- [ ] Logged-in app header: same search icon behavior as public header

🤖 Generated with [Claude Code](https://claude.com/claude-code)