### PR TITLE
Add X button and Escape key to dismiss modals (issue #19)

### DIFF
--- a/frontend/src/components/CreateOrgModal.jsx
+++ b/frontend/src/components/CreateOrgModal.jsx
@@ -1,10 +1,18 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { createOrganization } from "../api";
 
 export default function CreateOrgModal({ token, onCreated, onClose }) {
   const [name, setName] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === "Escape" && onClose) onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -23,6 +31,16 @@ export default function CreateOrgModal({ token, onCreated, onClose }) {
   return (
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal-card" onClick={(e) => e.stopPropagation()}>
+        {onClose && (
+          <button
+            type="button"
+            className="modal-close-x"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        )}
         <h2 className="modal-title">Create an Organization</h2>
         <p className="modal-subtitle">Name your organization to get started.</p>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1124,11 +1124,37 @@ select {
 }
 
 .modal-card {
+  position: relative;
   width: min(460px, 100%);
   border-radius: 16px;
   background: var(--color-surface);
   padding: 2rem;
   box-shadow: 0 20px 50px rgba(24, 57, 43, 0.18);
+}
+
+.modal-close-x {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  background: none;
+  color: var(--color-muted);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 0;
+  transition: background 0.15s, color 0.15s;
+}
+
+.modal-close-x:hover {
+  background: rgba(24, 57, 43, 0.08);
+  color: var(--color-ink);
 }
 
 .modal-title {


### PR DESCRIPTION
## Summary
- Adds a subtle × close button to the top-right corner of `CreateOrgModal`
- Adds Escape key support to dismiss the modal
- Adds `position: relative` to `.modal-card` and new `.modal-close-x` CSS styles

Closes #19

## Test plan
- [ ] Open the "Create an Organization" modal
- [ ] Confirm × button appears top-right
- [ ] Click × to close
- [ ] Press Escape to close
- [ ] Click backdrop to close (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)