### PR TITLE
Auth page copy cleanup + mobile form order

### DIFF
--- a/frontend/src/components/AuthPage.jsx
+++ b/frontend/src/components/AuthPage.jsx
@@ -54,18 +54,18 @@ export default function AuthPage({ loadOrganizations, onAuthenticated }) {
       <section className="auth-intro">
         <div>
           <h1 className="auth-intro-title">
-            {mode === "signup" ? "Create your free five* account" : "Welcome back to five*"}
+            {mode === "signup" ? "Create your free account" : "Welcome back"}
           </h1>
           <p className="auth-intro-copy">
-            Collect honest customer feedback, review clear summaries, and keep making your Baton
-            Rouge business better without adding another paid platform to your stack.
+            Collect honest customer feedback, review clear summaries, and keep making your
+            business better without adding another paid platform to your stack.
           </p>
         </div>
 
         <div className="auth-highlight-list">
           <div className="auth-highlight">
             <h2>Free to use</h2>
-            <p>Made to support the Baton Rouge business community, not sell into it.</p>
+            <p>Made to support local businesses, not sell into them.</p>
           </div>
           <div className="auth-highlight">
             <h2>Simple setup</h2>
@@ -91,7 +91,7 @@ export default function AuthPage({ loadOrganizations, onAuthenticated }) {
             {pendingInvite
               ? "Sign up or log in to accept your invite."
               : mode === "signup"
-                ? "Start improving customer experience with a free Baton Rouge account."
+                ? "Start improving customer experience — it's free."
                 : "Pick up where you left off."}
           </p>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -807,6 +807,10 @@ select {
     border-radius: 24px;
   }
 
+  .auth-card {
+    order: -1;
+  }
+
   .auth-card-head,
   .auth-card-body,
   .auth-intro,


### PR DESCRIPTION
## Summary
- Reduces overuse of "five*" and "Baton Rouge" on signup/login pages (fixes #18)
- Headlines now say "Create your free account" / "Welcome back" instead of repeating the brand name
- Removed "Baton Rouge" from intro paragraph, highlight card, and signup subtitle
- On mobile, the auth form card is now ordered above the intro section so users reach signup/login without scrolling

## Test plan
- [ ] Visit `/auth?mode=signup` on desktop — intro left, form right, copy is clean
- [ ] Visit `/auth?mode=login` on desktop — same layout, "Welcome back" headline
- [ ] Visit both on mobile — form appears first, no scrolling needed to reach fields
- [ ] Invite flow (`?invite=...`) still shows correct subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)