### PR TITLE
Fix deploy: add alembic to requirements and run migrations on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY --from=frontend-build /app/frontend/dist /app/frontend/dist
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ bcrypt==4.0.1
 pydantic-settings==2.7.1
 email-validator==2.2.0
 openai>=1.0.0
+alembic==1.14.0


### PR DESCRIPTION
## Summary

- Add `alembic==1.14.0` to `backend/requirements.txt` so it is installed in the container
- Add `alembic upgrade head &&` to the `CMD` in `Dockerfile` so migrations run on every deploy

## Why

PR #23 committed the missing Alembic config files and migrations, but didn't update the Dockerfile startup command or pin alembic in requirements. The app is currently working in production only because the DB schema happens to be current — but any future migration would silently not run (or crash if alembic isn't on the PATH).

## Test plan

- [ ] Deploy succeeds on Fly.io after merge
- [ ] `alembic upgrade head` runs cleanly in container startup logs (no pending migrations = `INFO  [alembic.runtime.migration] Running upgrade ...` or `No new upgrade ops`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)