### PR TITLE
Fix asterisk rendering inconsistency in logo and favicon

### DIFF
--- a/frontend/public/brand/five-star-logo.svg
+++ b/frontend/public/brand/five-star-logo.svg
@@ -6,7 +6,8 @@
             <text x="608.006px" y="850.581px" style="font-family:'AvenirNext-DemiBold', 'Avenir Next', sans-serif;font-weight:600;font-size:288px;">ﬁ<tspan x="775.91px " y="850.581px ">v</tspan></text>
             <text x="920.774px" y="850.581px" style="font-family:'AvenirNext-DemiBold', 'Avenir Next', sans-serif;font-weight:600;font-size:288px;">e</text>
             <g transform="matrix(1,0,-0.0524078,1,44.053,0)">
-                <text x="1031.37px" y="840.581px" style="font-family:'AndaleMono', 'Andale Mono', monospace;font-size:350px;">*</text>
+                <!-- Asterisk baked as a path (from Andale Mono's glyph) so it renders identically on every device, regardless of installed fonts -->
+                <path d="M1196.629,693.950 L1186.375,711.040 L1145.872,684.209 L1145.872,733.086 L1126.902,733.086 L1126.902,684.209 L1085.887,711.382 L1075.804,693.950 L1118.870,665.923 L1075.804,637.895 L1085.887,620.806 L1126.902,648.149 L1126.902,599.443 L1145.872,599.443 L1145.872,647.808 L1186.375,620.806 L1196.629,637.895 L1154.246,665.923 Z"/>
             </g>
         </g>
     </g>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,9 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
   <rect width="100" height="100" rx="22" fill="#ffffff"/>
-  <g transform="translate(50,50)">
-    <!-- Six-armed asterisk drawn as paths, centered at origin -->
-    <line x1="0" y1="-24" x2="0" y2="24" stroke="#000" stroke-width="9" stroke-linecap="round"/>
-    <line x1="-20.8" y1="-12" x2="20.8" y2="12" stroke="#000" stroke-width="9" stroke-linecap="round"/>
-    <line x1="-20.8" y1="12" x2="20.8" y2="-12" stroke="#000" stroke-width="9" stroke-linecap="round"/>
-  </g>
+  <!-- Same asterisk glyph path as brand/five-star-logo.svg, so the mark matches everywhere -->
+  <path fill="#000" d="M76.22,62.02 L71.77,69.43 L54.19,57.79 L54.19,79.00 L45.96,79.00 L45.96,57.79 L28.16,69.58 L23.78,62.02 L42.47,49.85 L23.78,37.69 L28.16,30.27 L45.96,42.14 L45.96,21.00 L54.19,21.00 L54.19,41.99 L71.77,30.27 L76.22,37.69 L57.82,49.85 Z"/>
 </svg>


### PR DESCRIPTION
## Summary
- The wordmark's `*` was rendered as live text set in `AndaleMono`, a font that isn't installed on most mobile devices — browsers there silently substituted a different-looking glyph, so the asterisk in the header logo didn't match between desktop and mobile.
- Baked the real Andale Mono glyph outline into `frontend/public/brand/five-star-logo.svg` as a fixed vector path, so it renders identically everywhere regardless of installed fonts.
- Updated `frontend/public/favicon.svg` to use the same glyph-derived path (it previously used a different hand-drawn asterisk design), so the browser tab icon now matches the header logo exactly.

## Test plan
- [x] Verified in-browser at mobile (375px) and desktop viewport widths — asterisk shape now matches
- [x] Verified favicon renders correctly with the same shape
- [x] Confirmed no console errors on load