### PR TITLE
Update homepage/signup copy for 2¢ fee and Louisiana-wide reach

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -209,7 +209,7 @@ function PublicHeader({ isAuthenticated }) {
     <header className="topbar topbar--public">
       <Link className="brand-lockup" to={isAuthenticated ? "/dashboard" : "/"}>
         <img className="topbar-logo" src={LOGO_SRC} alt="five*" />
-        <span className="brand-tag">Built in Baton Rouge for Baton Rouge businesses</span>
+        <span className="brand-tag">Built in Baton Rouge, serving businesses across Louisiana</span>
       </Link>
 
       {/* Right side — search always visible, nav toggles per breakpoint */}
@@ -228,7 +228,7 @@ function PublicHeader({ isAuthenticated }) {
                 Log in
               </Link>
               <Link className="btn btn--primary btn--sm" to="/auth?mode=signup">
-                Get started free
+                Get started
               </Link>
             </>
           )}
@@ -257,7 +257,7 @@ function PublicHeader({ isAuthenticated }) {
             ) : (
               <>
                 <Link className="menu-item" to="/auth?mode=signup" onClick={() => setIsMenuOpen(false)}>
-                  Get started free
+                  Get started
                 </Link>
                 <Link className="menu-item" to="/auth?mode=login" onClick={() => setIsMenuOpen(false)}>
                   Log in

--- a/frontend/src/components/AuthPage.jsx
+++ b/frontend/src/components/AuthPage.jsx
@@ -62,18 +62,18 @@ export default function AuthPage({ loadOrganizations, onAuthenticated }) {
       <section className="auth-intro">
         <div>
           <h1 className="auth-intro-title">
-            {mode === "signup" ? "Create your free account" : "Welcome back"}
+            {mode === "signup" ? "Create your account" : "Welcome back"}
           </h1>
           <p className="auth-intro-copy">
             Collect honest customer feedback, review clear summaries, and keep making your
-            business better without adding another paid platform to your stack.
+            business better for just 2 cents per customer submission.
           </p>
         </div>
 
         <div className="auth-highlight-list">
           <div className="auth-highlight">
-            <h2>Free to use</h2>
-            <p>Made to support local businesses, not sell into them.</p>
+            <h2>Just 2 cents per submission</h2>
+            <p>No subscriptions, no hidden fees — just pay for what you use.</p>
           </div>
           <div className="auth-highlight">
             <h2>Simple setup</h2>
@@ -103,7 +103,7 @@ export default function AuthPage({ loadOrganizations, onAuthenticated }) {
               : pendingInvite
                 ? "Sign up or log in to accept your invite."
                 : mode === "signup"
-                  ? "Start improving customer experience — it's free."
+                  ? "Start improving customer experience — just 2 cents per submission."
                   : "Pick up where you left off."}
           </p>
 

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -4,7 +4,7 @@ const PAIN_POINTS = [
   {
     title: "You don't have time to chase reviews",
     description:
-      "Most owners know something's off before a bad review hits. They just don't have a system to catch it early. five* gives you one, for free.",
+      "Most owners know something's off before a bad review hits. They just don't have a system to catch it early. five* gives you one, for just 2 cents per customer submission.",
   },
   {
     title: "Frustrated customers vent to you, not about you",
@@ -72,7 +72,7 @@ export default function MarketingPage() {
       <section className="marketing-hero">
         <div className="marketing-panel marketing-panel--hero">
           <h1 className="marketing-title">
-            Better feedback for Baton Rouge.
+            Better feedback for Louisiana businesses.
           </h1>
           <p className="marketing-copy">
             Your customers want you to succeed. They just need a way to tell you
@@ -82,7 +82,7 @@ export default function MarketingPage() {
 
           <div className="marketing-actions">
             <Link className="btn btn--primary" to="/auth?mode=signup">
-              Get started free
+              Get started
             </Link>
             <Link className="btn btn--ghost" to="/auth?mode=login">
               Log in
@@ -90,8 +90,8 @@ export default function MarketingPage() {
           </div>
 
           <div className="marketing-pill-row">
-            <span className="marketing-pill">Made for Baton Rouge</span>
-            <span className="marketing-pill">Free for local businesses</span>
+            <span className="marketing-pill">Serving North, Central &amp; South Louisiana</span>
+            <span className="marketing-pill">Just 2 cents per customer submission</span>
           </div>
         </div>
 
@@ -130,8 +130,8 @@ export default function MarketingPage() {
           <p className="section-kicker">Sound familiar?</p>
           <h2 className="section-title">The current system is broken.</h2>
           <p className="section-copy">
-            Baton Rouge people want to spend money here: food, dates, gatherings, and
-            everything that makes this city work. But there&apos;s no real way for customers
+            Louisiana people want to spend money here: food, dates, gatherings, and
+            everything that makes their communities work. But there&apos;s no real way for customers
             to work <em>with</em> businesses. Feedback either never happens, turns into gossip,
             or ends up as a bad review.
           </p>
@@ -195,8 +195,9 @@ export default function MarketingPage() {
           </p>
           <p className="section-copy" style={{marginTop: "0.75rem"}}>
             We don&apos;t put our mark behind a business we wouldn&apos;t stand behind ourselves.
-            five* exists to bring Baton Rouge customers and businesses closer together. The best
-            businesses are the ones that never stop listening.
+            five* exists to bring Louisiana customers and businesses closer together, from the
+            northern parishes down to the coast. The best businesses are the ones that never stop
+            listening.
           </p>
         </div>
       </section>
@@ -206,13 +207,13 @@ export default function MarketingPage() {
           <p className="section-kicker">Ready to start</p>
           <h2 className="section-title">Give your customers a way to help you improve.</h2>
           <p className="section-copy">
-            Create a free account, share your feedback link, and start learning what your business
-            needs next.
+            Create your account, share your feedback link, and start learning what your business
+            needs next &mdash; just 2 cents per customer submission.
           </p>
         </div>
 
         <Link className="btn btn--primary" to="/auth?mode=signup">
-          Get started free
+          Get started
         </Link>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Replace "free" messaging on the homepage, public header, and signup page with the actual 2-cents-per-customer-submission pricing
- Broaden Baton Rouge-only phrasing (hero, pill, header tag, closing section) to reflect statewide reach — "North, Central & South Louisiana" — instead of naming a fixed list of cities, since the app isn't limited to any one region

## Test plan
- [x] Ran the frontend dev server from this worktree and reviewed the homepage, public header, and signup (`/auth?mode=signup`) pages in-browser
- [x] Confirmed no leftover "free" pricing language remains on these pages
- [x] Confirmed hero, pill, and closing section reflect Louisiana-wide reach

🤖 Generated with [Claude Code](https://claude.com/claude-code)