### PR TITLE
Interactive homepage demo + marketing copy pass

### DIFF
--- a/frontend/src/components/DigestManager.jsx
+++ b/frontend/src/components/DigestManager.jsx
@@ -1,13 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from "recharts";
+import SubmissionsChart from "./SubmissionsChart";
 import {
   deleteDigest,
   generateDigest,
@@ -35,13 +27,6 @@ function daysAgoIso(n) {
 
 function todayIso() {
   return new Date().toISOString().slice(0, 10);
-}
-
-function formatChartDate(dateStr, days) {
-  const d = new Date(dateStr + "T00:00:00");
-  if (days <= 7) return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
-  if (days <= 90) return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-  return d.toLocaleDateString(undefined, { month: "short", year: "2-digit" });
 }
 
 // ─── ListEditor ─────────────────────────────────────────────────────────────
@@ -400,14 +385,6 @@ export default function DigestManager({ token, orgId, isAdmin }) {
 
   const totalInWindow = chartData.reduce((sum, d) => sum + d.count, 0);
 
-  // Format chart tick labels (show fewer ticks for large horizons)
-  const tickInterval = selectedHorizon.days <= 7 ? 0 : selectedHorizon.days <= 30 ? 2 : selectedHorizon.days <= 90 ? 6 : 29;
-
-  const formattedChartData = chartData.map((d) => ({
-    ...d,
-    label: formatChartDate(d.date, selectedHorizon.days),
-  }));
-
   return (
     <div className="settings-section">
       <h3 className="settings-heading">Feedback Digests</h3>
@@ -468,65 +445,12 @@ export default function DigestManager({ token, orgId, isAdmin }) {
       </div>
 
       {/* Chart */}
-      <div
-        style={{
-          background: "#fafcfd",
-          border: "1px solid #e3eaf0",
-          borderRadius: "12px",
-          padding: "1rem 0.5rem 0.5rem",
-          marginBottom: "1rem",
-        }}
-      >
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "0 0.75rem", marginBottom: "0.5rem" }}>
-          <span style={{ fontSize: "0.82rem", fontWeight: 700, color: "#5e6770", textTransform: "uppercase", letterSpacing: "0.04em" }}>
-            Submissions
-          </span>
-          {!chartLoading && (
-            <span style={{ fontSize: "0.82rem", color: "#5e6770" }}>
-              {totalInWindow} total
-            </span>
-          )}
-        </div>
-        {chartLoading ? (
-          <div style={{ height: 140, display: "grid", placeItems: "center", color: "#5e6770", fontSize: "0.9rem" }}>
-            Loading…
-          </div>
-        ) : (
-          <ResponsiveContainer width="100%" height={140}>
-            <LineChart data={formattedChartData} margin={{ top: 4, right: 12, left: -20, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e3eaf0" vertical={false} />
-              <XAxis
-                dataKey="label"
-                tick={{ fontSize: 11, fill: "#5e6770" }}
-                tickLine={false}
-                axisLine={false}
-                interval={tickInterval}
-              />
-              <YAxis
-                allowDecimals={false}
-                tick={{ fontSize: 11, fill: "#5e6770" }}
-                tickLine={false}
-                axisLine={false}
-                width={32}
-              />
-              <Tooltip
-                contentStyle={{ borderRadius: "8px", border: "1px solid #d6dfe6", fontSize: "0.88rem" }}
-                labelStyle={{ fontWeight: 700, color: "#2d1b42" }}
-                itemStyle={{ color: "#5a8faf" }}
-                formatter={(val) => [val, "submissions"]}
-              />
-              <Line
-                type="monotone"
-                dataKey="count"
-                stroke="#5a8faf"
-                strokeWidth={2}
-                dot={selectedHorizon.days <= 14 ? { r: 3, fill: "#5a8faf" } : false}
-                activeDot={{ r: 5 }}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        )}
-      </div>
+      <SubmissionsChart
+        data={chartData}
+        days={selectedHorizon.days}
+        loading={chartLoading}
+        total={totalInWindow}
+      />
 
       {/* Generate button */}
       {isAdmin && (

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -13,9 +13,9 @@ const PAIN_POINTS = [
       "When customers know you're listening, they bring problems to you privately instead of venting on Google and other review boards. five* gives them somewhere to go before that happens.",
   },
   {
-    title: "Too many channels, not enough signal",
+    title: "Stars don't tell you what to fix",
     description:
-      "Google, Yelp, Facebook. It's scattered and noisy. five* delivers what matters without the channel-hopping.",
+      "Google, Yelp, and Facebook shape how new customers judge you, so they matter. But a rating alone won't tell you what to change. five* gives you the honest feedback behind the scores, so you know exactly what to improve.",
   },
 ];
 
@@ -118,13 +118,13 @@ export default function MarketingPage() {
           <p className="section-kicker">The silent majority</p>
           <h2 className="section-title">Most customers who could help you never say a word.</h2>
           <p className="section-copy">
-            Think about the customer who noticed something off but didn&apos;t want to hurt your business.
-            They weren&apos;t going to leave a bad review. They weren&apos;t going to ask for the manager
-            either &mdash; that&apos;s not how most people are wired. So they said nothing, left a polite tip,
-            and you never found out &ndash; and you never saw them again.
+            Think about the customer who noticed something was off but didn&apos;t want to hurt your business.
+            They weren&apos;t going to leave a bad review, and they weren&apos;t going to ask for the manager
+            &mdash; that&apos;s just not how most people are wired. So they said nothing, left a polite tip,
+            and walked out &mdash; you never found out, and you never saw them again.
           </p>
           <p className="section-copy" style={{marginTop: "0.75rem"}}>
-            five* gives those customers somewhere to go. The ones who want to help, finally can &ndash; but in private.
+            five* gives those customers somewhere to go &mdash; so the ones who want to help finally can, in private.
           </p>
         </div>
       </section>
@@ -134,7 +134,7 @@ export default function MarketingPage() {
           <p className="section-kicker">Sound familiar?</p>
           <h2 className="section-title">The current system is broken.</h2>
           <p className="section-copy">
-            Louisiana people want to spend money here: food, dates, gatherings, and
+            People want to spend money at the places they love: food, dates, gatherings, and
             everything that makes their communities work. But there&apos;s no real way for customers
             to work <em>with</em> businesses. Feedback either never happens, turns into gossip,
             or ends up as a bad review.
@@ -172,7 +172,7 @@ export default function MarketingPage() {
 
       <section className="section-shell digest-section">
         <div className="section-header">
-          <p className="section-kicker">The payoff</p>
+          <p className="section-kicker">The result</p>
           <h2 className="section-title">One clear report built from many customer submissions.</h2>
           <p className="section-copy">
             We call this a report. five* turns raw feedback into a structured summary of patterns, priorities, and
@@ -201,9 +201,8 @@ export default function MarketingPage() {
           </p>
           <p className="section-copy" style={{marginTop: "0.75rem"}}>
             We don&apos;t put our mark behind a business we wouldn&apos;t stand behind ourselves.
-            five* exists to bring Louisiana customers and businesses closer together, from the
-            northern parishes down to the coast. The best businesses are the ones that never stop
-            listening.
+            five* exists to bring customers and businesses closer together. The best businesses
+            are the ones that never stop listening.
           </p>
         </div>
       </section>

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import HomeDemo from "./demo/HomeDemo";
 
 const PAIN_POINTS = [
   {
@@ -9,12 +10,12 @@ const PAIN_POINTS = [
   {
     title: "Frustrated customers vent to you, not about you",
     description:
-      "When customers know you're listening, they bring problems to you privately instead of venting on Google. five* gives them somewhere to go before that happens.",
+      "When customers know you're listening, they bring problems to you privately instead of venting on Google and other review boards. five* gives them somewhere to go before that happens.",
   },
   {
     title: "Too many channels, not enough signal",
     description:
-      "Google, Yelp, Facebook. It's scattered and noisy. five* pulls the signal out so you see what matters without the channel-hopping.",
+      "Google, Yelp, Facebook. It's scattered and noisy. five* delivers what matters without the channel-hopping.",
   },
 ];
 
@@ -35,35 +36,35 @@ const STEPS = [
     number: "03",
     title: "Turn feedback into next steps",
     description:
-      "five* turns submissions into a clear digest: patterns, priorities, and actions your team can use.",
+      "five* turns submissions into usable data including patterns, priorities, and actions your team can use.",
   },
 ];
 
 const DIGEST_FLOW = [
   {
-    number: "01",
+    marker: "›",
     title: "Gather many submissions",
     description:
       "Customers share feedback over time, giving you more than a few isolated comments to react to.",
   },
   {
-    number: "02",
-    title: "Turn patterns into a digest",
+    marker: "›",
+    title: "Turn patterns into a report",
     description:
-      "five* converts those submissions into an insight-driven digest with a summary, clear themes, and practical next steps.",
+      "five* converts those submissions into an insight-driven report with a summary, clear themes, and practical next steps.",
   },
   {
-    number: "03",
+    marker: "›",
     title: "Review, refine, and share",
     description:
-      "Review and modify the digest, then share it with your team so everyone is aligned on what to improve and what to protect.",
+      "Review and modify the report, then share it with your team so everyone is aligned on what to improve and what to protect.",
   },
 ];
 
 const BENEFITS = [
-  "Customers submit feedback privately, not as a public review",
-  "Anonymous or identified, customer's choice",
-  "AI-powered digests that surface what actually matters",
+  "Customers submit feedback privately, not publicly",
+  "Customers can remain anonymous or identify themselves for follow up discussion",
+  "AI-powered to provide your business with what actually matters",
 ];
 
 export default function MarketingPage() {
@@ -84,6 +85,9 @@ export default function MarketingPage() {
             <Link className="btn btn--primary" to="/auth?mode=signup">
               Get started
             </Link>
+            <a className="btn btn--outline" href="#demo">
+              See a live demo
+            </a>
             <Link className="btn btn--ghost" to="/auth?mode=login">
               Log in
             </Link>
@@ -117,10 +121,10 @@ export default function MarketingPage() {
             Think about the customer who noticed something off but didn&apos;t want to hurt your business.
             They weren&apos;t going to leave a bad review. They weren&apos;t going to ask for the manager
             either &mdash; that&apos;s not how most people are wired. So they said nothing, left a polite tip,
-            and you never found out.
+            and you never found out &ndash; and you never saw them again.
           </p>
           <p className="section-copy" style={{marginTop: "0.75rem"}}>
-            five* gives those customers somewhere to go. The ones who want to help, finally can.
+            five* gives those customers somewhere to go. The ones who want to help, finally can &ndash; but in private.
           </p>
         </div>
       </section>
@@ -164,20 +168,22 @@ export default function MarketingPage() {
         </div>
       </section>
 
+      <HomeDemo />
+
       <section className="section-shell digest-section">
         <div className="section-header">
-          <p className="section-kicker">What&apos;s a digest?</p>
-          <h2 className="section-title">One clear summary built from many customer submissions.</h2>
+          <p className="section-kicker">The payoff</p>
+          <h2 className="section-title">One clear report built from many customer submissions.</h2>
           <p className="section-copy">
-            A digest turns raw feedback into a structured summary of patterns, priorities, and
+            We call this a report. five* turns raw feedback into a structured summary of patterns, priorities, and
             next steps your team can act on. No more reading every comment one by one.
           </p>
         </div>
 
         <div className="digest-flow-grid">
           {DIGEST_FLOW.map((item) => (
-            <article className="marketing-card digest-flow-card" key={item.number}>
-              <p className="marketing-step-number">{item.number}</p>
+            <article className="marketing-card digest-flow-card" key={item.title}>
+              <p className="marketing-step-number digest-flow-marker">{item.marker}</p>
               <h3 className="marketing-card-title">{item.title}</h3>
               <p className="marketing-card-copy">{item.description}</p>
             </article>

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -73,7 +73,7 @@ export default function MarketingPage() {
       <section className="marketing-hero">
         <div className="marketing-panel marketing-panel--hero">
           <h1 className="marketing-title">
-            Better feedback for Louisiana businesses.
+            Better feedback for businesses that listen.
           </h1>
           <p className="marketing-copy">
             Your customers want you to succeed. They just need a way to tell you
@@ -94,7 +94,7 @@ export default function MarketingPage() {
           </div>
 
           <div className="marketing-pill-row">
-            <span className="marketing-pill">Serving North, Central &amp; South Louisiana</span>
+            <span className="marketing-pill">Proudly built in Louisiana</span>
             <span className="marketing-pill">Just 2 cents per customer submission</span>
           </div>
         </div>

--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -5,7 +5,7 @@ const PAIN_POINTS = [
   {
     title: "You don't have time to chase reviews",
     description:
-      "Most owners know something's off before a bad review hits. They just don't have a system to catch it early. five* gives you one, for just 2 cents per customer submission.",
+      "You often know something's off before a bad review hits. You just don't have a system to catch it early. five* gives you one, for just 2 cents per customer submission.",
   },
   {
     title: "Frustrated customers vent to you, not about you",
@@ -100,8 +100,8 @@ export default function MarketingPage() {
         </div>
 
         <aside className="marketing-panel marketing-panel--aside">
-          <p className="section-kicker">What owners get</p>
-          <h2 className="marketing-side-title">A lightweight system that helps businesses hear what matters.</h2>
+          <p className="section-kicker">What you get</p>
+          <h2 className="marketing-side-title">A lightweight system that helps you hear what matters.</h2>
           <div className="marketing-benefit-list">
             {BENEFITS.map((benefit) => (
               <div className="marketing-benefit" key={benefit}>

--- a/frontend/src/components/SubmissionsChart.jsx
+++ b/frontend/src/components/SubmissionsChart.jsx
@@ -1,0 +1,88 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+function formatChartDate(dateStr, days) {
+  const d = new Date(dateStr + "T00:00:00");
+  if (days <= 7) return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+  if (days <= 90) return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return d.toLocaleDateString(undefined, { month: "short", year: "2-digit" });
+}
+
+export default function SubmissionsChart({ data, days, loading = false, total, height = 140 }) {
+  // Show fewer ticks for large horizons
+  const tickInterval = days <= 7 ? 0 : days <= 30 ? 2 : days <= 90 ? 6 : 29;
+
+  const formattedData = data.map((d) => ({
+    ...d,
+    label: formatChartDate(d.date, days),
+  }));
+
+  return (
+    <div
+      style={{
+        background: "#fafcfd",
+        border: "1px solid #e3eaf0",
+        borderRadius: "12px",
+        padding: "1rem 0.5rem 0.5rem",
+        marginBottom: "1rem",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "0 0.75rem", marginBottom: "0.5rem" }}>
+        <span style={{ fontSize: "0.82rem", fontWeight: 700, color: "#5e6770", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+          Submissions
+        </span>
+        {!loading && (
+          <span style={{ fontSize: "0.82rem", color: "#5e6770" }}>
+            {total} total
+          </span>
+        )}
+      </div>
+      {loading ? (
+        <div style={{ height, display: "grid", placeItems: "center", color: "#5e6770", fontSize: "0.9rem" }}>
+          Loading…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={height}>
+          <LineChart data={formattedData} margin={{ top: 4, right: 12, left: -20, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e3eaf0" vertical={false} />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11, fill: "#5e6770" }}
+              tickLine={false}
+              axisLine={false}
+              interval={tickInterval}
+            />
+            <YAxis
+              allowDecimals={false}
+              tick={{ fontSize: 11, fill: "#5e6770" }}
+              tickLine={false}
+              axisLine={false}
+              width={32}
+            />
+            <Tooltip
+              contentStyle={{ borderRadius: "8px", border: "1px solid #d6dfe6", fontSize: "0.88rem" }}
+              labelStyle={{ fontWeight: 700, color: "#2d1b42" }}
+              itemStyle={{ color: "#5a8faf" }}
+              formatter={(val) => [val, "submissions"]}
+            />
+            <Line
+              type="monotone"
+              dataKey="count"
+              stroke="#5a8faf"
+              strokeWidth={2}
+              dot={days <= 14 ? { r: 3, fill: "#5a8faf" } : false}
+              activeDot={{ r: 5 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/demo/DemoDashboardScreen.jsx
+++ b/frontend/src/components/demo/DemoDashboardScreen.jsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import SubmissionsChart from "../SubmissionsChart";
+import DemoDigestView, { DIGEST_FORMATS } from "./DemoDigestView";
+import { DEMO_ORG, DEMO_DIGEST, DEMO_FEEDBACK_ENTRIES, DEMO_PREFILLED_REVIEW, demoStats } from "./demoData";
+
+const STATS = demoStats(30);
+const STATS_TOTAL = STATS.reduce((sum, d) => sum + d.count, 0);
+
+export function DemoDigestCard({ published = false, format = "full", children }) {
+  return (
+    <div className="demo-digest-card">
+      <div className="demo-digest-head">
+        <span className={`demo-badge ${published ? "demo-badge--published" : "demo-badge--draft"}`}>
+          {published ? "Published" : "Draft"}
+        </span>
+        <span className="demo-digest-period">
+          {DEMO_DIGEST.period_start} → {DEMO_DIGEST.period_end}
+        </span>
+        <span className="demo-digest-count">{DEMO_DIGEST.feedback_count} submissions</span>
+      </div>
+      <div className="demo-digest-body">
+        {children}
+        <DemoDigestView format={format} />
+      </div>
+    </div>
+  );
+}
+
+export default function DemoDashboardScreen({ focus, digestGenerated, onGenerated, format, onFormatChange }) {
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  function handleGenerate() {
+    setIsGenerating(true);
+    // Simulated AI — the digest is pre-written, no API call.
+    setTimeout(() => {
+      setIsGenerating(false);
+      onGenerated();
+    }, 1200);
+  }
+
+  const showFormats = focus === "formats";
+
+  return (
+    <div className="demo-screen demo-screen--wide">
+      <div className="demo-dash-header">
+        <h2 className="demo-dash-title">{DEMO_ORG.name}</h2>
+        <span className="demo-owner-pill">Owner view</span>
+      </div>
+
+      <div className="demo-dash-panel">
+        <h3 className="demo-dash-heading">Feedback Reports</h3>
+        <p className="demo-dash-meta">
+          Summarize feedback into a structured report and share it with your organization.
+        </p>
+
+        <div className="demo-horizon-row">
+          <span className="demo-horizon-pill">Last month</span>
+        </div>
+
+        <SubmissionsChart data={STATS} days={30} total={STATS_TOTAL} height={110} />
+
+        {!showFormats && (
+          <div className="demo-recent-list">
+            <p className="demo-digest-label">Recent submissions</p>
+            <div className="demo-recent-item demo-recent-item--yours">
+              <p>{DEMO_PREFILLED_REVIEW.text}</p>
+              <p className="demo-recent-meta">
+                just now · {DEMO_PREFILLED_REVIEW.name} <span className="demo-recent-badge">that&apos;s yours</span>
+              </p>
+            </div>
+            {DEMO_FEEDBACK_ENTRIES.slice(0, 2).map((entry) => (
+              <div className="demo-recent-item" key={entry.content}>
+                <p>{entry.content}</p>
+                <p className="demo-recent-meta">{entry.meta}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!digestGenerated ? (
+          <div className="demo-generate-row">
+            <button
+              type="button"
+              className="btn btn--primary"
+              onClick={handleGenerate}
+              disabled={isGenerating}
+            >
+              {isGenerating ? "Generating report…" : "Generate Report for last month"}
+            </button>
+            {isGenerating && (
+              <p className="demo-dash-meta">
+                This may take a few seconds while the AI processes your feedback…
+              </p>
+            )}
+          </div>
+        ) : (
+          <DemoDigestCard format={showFormats ? format : "full"}>
+            {showFormats && (
+              <div className="demo-format-pills">
+                {DIGEST_FORMATS.map((f) => (
+                  <button
+                    key={f.id}
+                    type="button"
+                    className={`demo-format-pill ${format === f.id ? "demo-format-pill--active" : ""}`}
+                    onClick={() => onFormatChange(f.id)}
+                  >
+                    {f.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </DemoDigestCard>
+        )}
+
+        {showFormats && (
+          <p className="demo-note">
+            One report, five ways to read it — try the formats above. You can also edit any line before sharing.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/demo/DemoDigestView.jsx
+++ b/frontend/src/components/demo/DemoDigestView.jsx
@@ -1,0 +1,119 @@
+import { DEMO_DIGEST, DEMO_ORG } from "./demoData";
+
+export const DIGEST_FORMATS = [
+  { id: "full", label: "Full report" },
+  { id: "bullets", label: "Quick bullets" },
+  { id: "actions", label: "Action plan" },
+  { id: "summary", label: "Summary only" },
+  { id: "email", label: "Team email" },
+];
+
+function Section({ label, children }) {
+  return (
+    <div>
+      <p className="demo-digest-label">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+function BulletList({ items }) {
+  return (
+    <ul className="demo-digest-list">
+      {items.map((item, i) => (
+        <li key={i}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default function DemoDigestView({ format = "full" }) {
+  const digest = DEMO_DIGEST;
+
+  if (format === "bullets") {
+    return (
+      <div className="demo-digest-view">
+        <Section label="Insights">
+          <BulletList items={digest.insights} />
+        </Section>
+      </div>
+    );
+  }
+
+  if (format === "actions") {
+    return (
+      <div className="demo-digest-view">
+        <Section label="This week">
+          <ul className="demo-check-list">
+            {digest.immediate_actions.map((item, i) => (
+              <li key={i}>
+                <span className="demo-check-box" aria-hidden="true">☐</span> {item}
+              </li>
+            ))}
+          </ul>
+        </Section>
+        <Section label="Later">
+          <ul className="demo-check-list">
+            {digest.long_term_goals.map((item, i) => (
+              <li key={i}>
+                <span className="demo-check-box" aria-hidden="true">☐</span> {item}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      </div>
+    );
+  }
+
+  if (format === "summary") {
+    return (
+      <div className="demo-digest-view">
+        <p className="demo-digest-summary-only">{digest.summary}</p>
+      </div>
+    );
+  }
+
+  if (format === "email") {
+    return (
+      <div className="demo-email-preview">
+        <div className="demo-email-head">
+          <p><strong>Subject:</strong> Weekly feedback digest — {DEMO_ORG.name}</p>
+          <p><strong>To:</strong> Everyone at {DEMO_ORG.name}</p>
+        </div>
+        <div className="demo-email-body">
+          <p>Hi team,</p>
+          <p>
+            Here&apos;s what our customers told us over the last 30 days
+            ({digest.feedback_count} submissions):
+          </p>
+          <p>{digest.summary}</p>
+          <p><strong>Top 3 actions this week:</strong></p>
+          <ol>
+            {digest.immediate_actions.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ol>
+          <p>— sent with five*</p>
+        </div>
+      </div>
+    );
+  }
+
+  // "full" — mirrors the real DigestViewer structure
+  return (
+    <div className="demo-digest-view">
+      <Section label="Summary">
+        <p className="demo-digest-summary">{digest.summary}</p>
+      </Section>
+      <Section label="Insights">
+        <BulletList items={digest.insights} />
+      </Section>
+      <Section label="Immediate Actions">
+        <BulletList items={digest.immediate_actions} />
+      </Section>
+      <Section label="Long-Term Goals">
+        <BulletList items={digest.long_term_goals} />
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/components/demo/DemoFeedbackScreen.jsx
+++ b/frontend/src/components/demo/DemoFeedbackScreen.jsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import {
+  DEMO_ORG,
+  DEMO_PREFILLED_REVIEW,
+  DEMO_POLISHED_VARIANTS,
+  DEMO_REVIEW_LINKS,
+} from "./demoData";
+
+const PLATFORM_LABELS = { google: "Google Reviews", yelp: "Yelp", tripadvisor: "TripAdvisor" };
+
+function FeedbackForm({ onSubmitted }) {
+  const [content, setContent] = useState(DEMO_PREFILLED_REVIEW.text);
+  const [name, setName] = useState(DEMO_PREFILLED_REVIEW.name);
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    setIsSubmitting(true);
+    // Simulated network delay — nothing is actually sent anywhere.
+    setTimeout(() => onSubmitted(content), 500);
+  }
+
+  return (
+    <div className="feedback-card">
+      <h2 className="feedback-title">Share Your Feedback</h2>
+      <p className="feedback-subtitle">
+        Send anonymous feedback to <strong>{DEMO_ORG.name}</strong>
+      </p>
+
+      <form className="feedback-form" onSubmit={handleSubmit}>
+        <label className="field-label" htmlFor="demo-content">Your feedback *</label>
+        <textarea
+          className="field-textarea"
+          id="demo-content"
+          rows="4"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          required
+          maxLength={5000}
+        />
+
+        <div className="feedback-optional">
+          <p className="feedback-optional-label">Optional: Add your contact info (not required)</p>
+          <label className="field-label" htmlFor="demo-name">Your name</label>
+          <input
+            className="field-input"
+            id="demo-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={255}
+          />
+          <label className="field-label" htmlFor="demo-email">Your email</label>
+          <input
+            className="field-input"
+            id="demo-email"
+            type="email"
+            placeholder="alex@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+
+        <button className="btn btn--primary btn--large" type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Submitting..." : "Submit Feedback"}
+        </button>
+        <p className="demo-note">We prefilled this one for you — edit it if you like, then hit submit.</p>
+      </form>
+    </div>
+  );
+}
+
+function ShareBoost({ draft, onDraftChange }) {
+  const [isPolishing, setIsPolishing] = useState(false);
+  const [activeStyle, setActiveStyle] = useState(null);
+  const [draftCopied, setDraftCopied] = useState(false);
+  const [platformNote, setPlatformNote] = useState("");
+
+  const isModified = draft !== DEMO_PREFILLED_REVIEW.text;
+
+  function handlePolish(style) {
+    setIsPolishing(true);
+    setPlatformNote("");
+    // Simulated AI — pre-written variants, no API call.
+    setTimeout(() => {
+      onDraftChange(DEMO_POLISHED_VARIANTS[style]);
+      setActiveStyle(style);
+      setIsPolishing(false);
+      setDraftCopied(false);
+    }, 600);
+  }
+
+  function handleUseOriginal() {
+    onDraftChange(DEMO_PREFILLED_REVIEW.text);
+    setActiveStyle(null);
+    setDraftCopied(false);
+  }
+
+  async function copyDraft() {
+    try {
+      await navigator.clipboard.writeText(draft);
+    } catch {
+      // clipboard unavailable — still show feedback so the demo flows
+    }
+    setDraftCopied(true);
+    setTimeout(() => setDraftCopied(false), 2000);
+  }
+
+  function handlePlatformClick(platform) {
+    copyDraft();
+    setPlatformNote(
+      `Copied your review — in the real app this opens ${DEMO_ORG.name}'s ${PLATFORM_LABELS[platform]} page.`
+    );
+  }
+
+  return (
+    <div className="feedback-card">
+      <h2 className="feedback-title">Feedback submitted</h2>
+      <p className="feedback-subtitle">
+        Thank you for sharing with <strong>{DEMO_ORG.name}</strong>.
+      </p>
+
+      <div className="review-share-section">
+        <p className="review-share-heading">Want to share publicly?</p>
+        <p className="review-share-desc">Your draft is ready to copy and paste to a review site.</p>
+
+        <div className="review-draft-box">
+          <textarea
+            className="review-draft-textarea"
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            rows={4}
+          />
+          <div className="review-draft-actions">
+            <div className="review-polish-buttons">
+              {["shorten", "polish", "simplify"].map((style) => (
+                <button
+                  key={style}
+                  type="button"
+                  className={`btn btn--ghost btn--sm ${activeStyle === style ? "demo-polish-active" : ""}`}
+                  onClick={() => handlePolish(style)}
+                  disabled={isPolishing}
+                >
+                  {style.charAt(0).toUpperCase() + style.slice(1)}
+                </button>
+              ))}
+              {isPolishing && <span className="review-polish-status">Polishing…</span>}
+              {!isPolishing && isModified && (
+                <button type="button" className="demo-use-original" onClick={handleUseOriginal}>
+                  Use original
+                </button>
+              )}
+            </div>
+            <button type="button" className="btn btn--primary btn--sm" onClick={copyDraft}>
+              {draftCopied ? "Copied!" : "Copy"}
+            </button>
+          </div>
+        </div>
+
+        <div className="review-platform-links">
+          {DEMO_REVIEW_LINKS.map((link) => (
+            <button
+              key={link.platform}
+              type="button"
+              className="btn btn--outline"
+              onClick={() => handlePlatformClick(link.platform)}
+            >
+              {PLATFORM_LABELS[link.platform]}
+            </button>
+          ))}
+        </div>
+        {platformNote ? (
+          <p className="review-share-hint demo-platform-note">{platformNote}</p>
+        ) : (
+          <p className="review-share-hint">Clicking a platform copies your draft automatically.</p>
+        )}
+        <p className="demo-note">
+          These links are set by the business — you pick which platforms to send your customers to.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function DemoFeedbackScreen({ stage, draft, onDraftChange, onSubmitted }) {
+  return (
+    <div className="demo-screen">
+      {stage === "boost" ? (
+        <ShareBoost draft={draft} onDraftChange={onDraftChange} />
+      ) : (
+        <FeedbackForm onSubmitted={onSubmitted} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/demo/DemoSearchScreen.jsx
+++ b/frontend/src/components/demo/DemoSearchScreen.jsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { DEMO_ORG, DEMO_SEARCH_RESULTS } from "./demoData";
+
+export default function DemoSearchScreen({ onSelect }) {
+  const [query, setQuery] = useState("magnolia");
+
+  const trimmed = query.trim().toLowerCase();
+  const results =
+    trimmed.length >= 2
+      ? DEMO_SEARCH_RESULTS.filter((org) => org.name.toLowerCase().includes(trimmed))
+      : [];
+
+  return (
+    <div className="demo-screen">
+      <div className="search-container demo-search-container">
+        <h1 className="search-title">Find an Organization</h1>
+        <p className="search-subtitle">Search for an organization to share your feedback</p>
+
+        <div className="search-box">
+          <input
+            type="text"
+            className="search-input"
+            placeholder="Search by organization name..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+
+        {results.length > 0 ? (
+          <div className="search-results">
+            <p className="search-results-count">
+              Found {results.length} organization{results.length !== 1 ? "s" : ""}
+            </p>
+            <ul className="search-results-list">
+              {results.map((org) => (
+                <li key={org.id} className="search-result-item">
+                  <button
+                    type="button"
+                    className="search-result-button"
+                    onClick={() => onSelect(org)}
+                  >
+                    <span className="search-result-name">{org.name}</span>
+                    <span className="search-result-arrow">→</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <p className="demo-note">
+              Click <strong>{DEMO_ORG.name}</strong> to leave them feedback.
+            </p>
+          </div>
+        ) : (
+          <p className="search-no-results">
+            {trimmed.length >= 2
+              ? `No organizations found matching "${query}". Try "magnolia".`
+              : "Try typing “magnolia”."}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/demo/DemoShareScreen.jsx
+++ b/frontend/src/components/demo/DemoShareScreen.jsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import DemoDigestView from "./DemoDigestView";
+import { DEMO_DIGEST, DEMO_MEMBERS, DEMO_ORG } from "./demoData";
+
+export default function DemoShareScreen({ published, onPublish }) {
+  const [isPublishing, setIsPublishing] = useState(false);
+
+  function handlePublish() {
+    setIsPublishing(true);
+    setTimeout(() => {
+      setIsPublishing(false);
+      onPublish();
+    }, 700);
+  }
+
+  return (
+    <div className="demo-screen demo-screen--wide">
+      <div className="demo-dash-header">
+        <h2 className="demo-dash-title">{DEMO_ORG.name}</h2>
+        <span className="demo-owner-pill">Owner view</span>
+      </div>
+
+      <div className="demo-dash-panel">
+        <div className="demo-digest-card">
+          <div className="demo-digest-head">
+            <span className={`demo-badge ${published ? "demo-badge--published" : "demo-badge--draft"}`}>
+              {published ? "Published" : "Draft"}
+            </span>
+            <span className="demo-digest-period">
+              {DEMO_DIGEST.period_start} → {DEMO_DIGEST.period_end}
+            </span>
+            <span className="demo-digest-count">{DEMO_DIGEST.feedback_count} submissions</span>
+          </div>
+          <div className="demo-digest-body">
+            <p className="demo-digest-label">Summary</p>
+            <p className="demo-digest-summary">{DEMO_DIGEST.summary}</p>
+            {!published && (
+              <div className="demo-share-row">
+                <button
+                  type="button"
+                  className="btn btn--sm demo-btn-share"
+                  onClick={handlePublish}
+                  disabled={isPublishing}
+                >
+                  {isPublishing ? "Publishing…" : "Share with Organization"}
+                </button>
+                <p className="demo-note">Publishing makes the report visible to everyone on your team.</p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {published && (
+          <div className="demo-team-panel">
+            <h3 className="demo-dash-heading">What your team sees</h3>
+            <p className="demo-dash-meta">
+              Everyone at {DEMO_ORG.name} now sees the same published report — same priorities, no forwarding screenshots.
+            </p>
+
+            <div className="demo-table-scroll">
+              <table className="members-table">
+                <thead>
+                  <tr>
+                    <th>Email</th>
+                    <th>Role</th>
+                    <th>Joined</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {DEMO_MEMBERS.map((m) => (
+                    <tr key={m.email} className={m.isSelf ? "members-row--self" : ""}>
+                      <td>
+                        {m.email}
+                        {m.isSelf && <span className="demo-recent-badge">you</span>}
+                      </td>
+                      <td>{m.role}</td>
+                      <td>{m.joined}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <p className="demo-share-finale">
+              That&apos;s the whole loop — a customer spoke up, and your whole team knows what to do next.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/demo/HomeDemo.jsx
+++ b/frontend/src/components/demo/HomeDemo.jsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import DemoSearchScreen from "./DemoSearchScreen";
+import DemoFeedbackScreen from "./DemoFeedbackScreen";
+import DemoDashboardScreen from "./DemoDashboardScreen";
+import DemoShareScreen from "./DemoShareScreen";
+import { DEMO_ORG, DEMO_PREFILLED_REVIEW, DEMO_STEPS } from "./demoData";
+
+const DASHBOARD_STEP = 5; // index of the owner-dashboard step
+
+export default function HomeDemo() {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [draft, setDraft] = useState(DEMO_PREFILLED_REVIEW.text);
+  const [digestGenerated, setDigestGenerated] = useState(false);
+  const [digestPublished, setDigestPublished] = useState(false);
+  const [digestFormat, setDigestFormat] = useState("full");
+
+  const step = DEMO_STEPS[stepIndex];
+  const isLast = stepIndex === DEMO_STEPS.length - 1;
+
+  function goTo(index) {
+    // Keep later steps consistent even if scripted actions were skipped
+    if (index > DASHBOARD_STEP) setDigestGenerated(true);
+    setStepIndex(Math.max(0, Math.min(index, DEMO_STEPS.length - 1)));
+  }
+
+  function restart() {
+    setStepIndex(0);
+    setDraft(DEMO_PREFILLED_REVIEW.text);
+    setDigestGenerated(false);
+    setDigestPublished(false);
+    setDigestFormat("full");
+  }
+
+  function renderStep() {
+    switch (step.id) {
+      case "intro":
+        return (
+          <div className="demo-screen">
+            <div className="demo-inter-card">
+              <p className="section-kicker">Interactive demo</p>
+              <h3 className="demo-inter-title">See five* from both sides.</h3>
+              <p className="demo-inter-copy">
+                First you&apos;ll play the customer leaving feedback for{" "}
+                <strong>{DEMO_ORG.name}</strong>, a (fictional) café in {DEMO_ORG.city}. Then
+                you&apos;ll switch sides and see exactly what the owner gets.
+              </p>
+              <button type="button" className="btn btn--primary" onClick={() => goTo(1)}>
+                Start the demo →
+              </button>
+            </div>
+          </div>
+        );
+      case "search":
+        return <DemoSearchScreen onSelect={() => goTo(2)} />;
+      case "feedback":
+        return (
+          <DemoFeedbackScreen
+            stage="form"
+            onSubmitted={(content) => {
+              setDraft(content);
+              goTo(3);
+            }}
+          />
+        );
+      case "boost":
+        return <DemoFeedbackScreen stage="boost" draft={draft} onDraftChange={setDraft} />;
+      case "flip":
+        return (
+          <div className="demo-screen">
+            <div className="demo-inter-card">
+              <p className="section-kicker">Switching sides</p>
+              <h3 className="demo-inter-title">That took your customer about 30 seconds.</h3>
+              <p className="demo-inter-copy">
+                No account, no public post, no awkward conversation. Now see what all that
+                honest feedback turns into for <strong>you</strong>, the owner.
+              </p>
+              <button type="button" className="btn btn--primary" onClick={() => goTo(5)}>
+                View the owner dashboard →
+              </button>
+            </div>
+          </div>
+        );
+      case "dashboard":
+        return (
+          <DemoDashboardScreen
+            digestGenerated={digestGenerated}
+            onGenerated={() => setDigestGenerated(true)}
+            format={digestFormat}
+            onFormatChange={setDigestFormat}
+          />
+        );
+      case "formats":
+        return (
+          <DemoDashboardScreen
+            focus="formats"
+            digestGenerated
+            onGenerated={() => setDigestGenerated(true)}
+            format={digestFormat}
+            onFormatChange={setDigestFormat}
+          />
+        );
+      case "share":
+        return (
+          <DemoShareScreen
+            published={digestPublished}
+            onPublish={() => setDigestPublished(true)}
+          />
+        );
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <section className="section-shell home-demo" id="demo">
+      <div className="section-header">
+        <p className="section-kicker">Try it</p>
+        <h2 className="section-title">See the whole loop in 60 seconds.</h2>
+        <p className="section-copy">
+          Click through a real example — first as your customer, then as you. Nothing here is
+          live and no account is needed.
+        </p>
+      </div>
+
+      <div className="home-demo-captionbar">
+        <span className="demo-kicker-chip">{step.kicker}</span>
+        <p className="demo-caption">{step.caption}</p>
+        <span className="demo-step-count">Step {stepIndex + 1} of {DEMO_STEPS.length}</span>
+      </div>
+
+      <div className="home-demo-frame">
+        <div className="home-demo-chrome">
+          <span className="home-demo-chrome-dots" aria-hidden="true">
+            <span className="home-demo-chrome-dot" />
+            <span className="home-demo-chrome-dot" />
+            <span className="home-demo-chrome-dot" />
+          </span>
+          <span className="home-demo-url">{step.url}</span>
+        </div>
+        <div
+          className={`home-demo-stage ${stepIndex === DASHBOARD_STEP ? "home-demo-stage--flip" : ""}`}
+          key={stepIndex}
+        >
+          {renderStep()}
+        </div>
+      </div>
+
+      <div className="home-demo-controls">
+        <button
+          type="button"
+          className="btn btn--ghost btn--sm"
+          onClick={() => goTo(stepIndex - 1)}
+          disabled={stepIndex === 0}
+        >
+          ← Back
+        </button>
+
+        <div className="demo-dots" role="tablist" aria-label="Demo steps">
+          {DEMO_STEPS.map((s, i) => (
+            <button
+              key={s.id}
+              type="button"
+              className={`demo-dot ${i === stepIndex ? "demo-dot--active" : ""}`}
+              onClick={() => goTo(i)}
+              aria-label={`Go to step ${i + 1}`}
+            />
+          ))}
+        </div>
+
+        <div className="demo-controls-right">
+          <button type="button" className="demo-restart" onClick={restart}>
+            Restart
+          </button>
+          {isLast ? (
+            <Link className="btn btn--primary btn--sm" to="/auth?mode=signup">
+              Get started
+            </Link>
+          ) : (
+            <button
+              type="button"
+              className="btn btn--primary btn--sm"
+              onClick={() => goTo(stepIndex + 1)}
+            >
+              Next →
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/demo/demoData.js
+++ b/frontend/src/components/demo/demoData.js
@@ -1,0 +1,160 @@
+// Static data powering the homepage demo. Everything is fictional and
+// hardcoded — the demo never touches the API.
+
+function daysAgoIso(n) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+export const DEMO_ORG = {
+  name: "Magnolia Roux Coffee & Kitchen",
+  city: "Baton Rouge, LA",
+};
+
+export const DEMO_SEARCH_RESULTS = [
+  { id: "magnolia-roux", name: "Magnolia Roux Coffee & Kitchen" },
+  { id: "magnolia-diner", name: "Magnolia Street Diner" },
+  { id: "roux-rye", name: "Roux & Rye Bistro" },
+];
+
+export const DEMO_PREFILLED_REVIEW = {
+  name: "Alex T.",
+  text:
+    "The cold brew is the best in Baton Rouge, hands down, and the staff always remembers my order. " +
+    "Only gripe: the line on Saturday mornings gets really long — I've bailed a couple of times when I was in a hurry.",
+};
+
+export const DEMO_POLISHED_VARIANTS = {
+  shorten:
+    "Best cold brew in Baton Rouge and a staff that remembers your order. Just wish the Saturday morning line moved faster.",
+  polish:
+    "Magnolia Roux serves the best cold brew in Baton Rouge, and the staff's warmth makes every visit feel personal — they remember my order every time. My only suggestion would be extra help at the counter on Saturday mornings, when the line can get long.",
+  simplify:
+    "Great coffee and friendly staff. The line on Saturday mornings is too long, but everything else is perfect.",
+};
+
+// Matches the shape of Organization.review_links in the real app.
+export const DEMO_REVIEW_LINKS = [
+  { platform: "google", url: "#" },
+  { platform: "yelp", url: "#" },
+];
+
+export const DEMO_FEEDBACK_ENTRIES = [
+  { content: "Saturday line was out the door again — I love y'all but I can't spend 25 minutes waiting on a latte.", meta: "2 days ago · Anonymous" },
+  { content: "Miss Renee at the counter is the reason I keep coming back. She remembers everybody.", meta: "3 days ago · Jasmine B." },
+  { content: "Almond croissants were gone by 9:45 again. Please make more!", meta: "5 days ago · Anonymous" },
+  { content: "Any chance of oat milk? Half my friends can't do dairy.", meta: "6 days ago · Anonymous" },
+  { content: "Patio table by the door wobbles so bad I spilled my cortado.", meta: "1 week ago · Marcus D." },
+  { content: "Wi-Fi kept dropping around lunch. Otherwise a perfect work spot.", meta: "1 week ago · Anonymous" },
+  { content: "Love the punch card! Free 10th drink got me to switch from the chain up the road.", meta: "2 weeks ago · Anonymous" },
+  { content: "Best gumbo-and-coffee combo in Baton Rouge. Don't change a thing.", meta: "2 weeks ago · Tara L." },
+];
+
+// 30 days of submission counts, oldest → newest. Sums to 23 (the digest's
+// feedback_count), with today's count including the review submitted in the demo.
+const DAILY_PATTERN = [
+  0, 1, 1, 0, 2, 1, 1,
+  0, 1, 0, 2, 1, 0, 1,
+  1, 0, 1, 1, 0, 1, 0,
+  1, 1, 0, 2, 0, 1, 0,
+  1, 2,
+];
+
+export function demoStats(days = 30) {
+  const data = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const idx = days - 1 - i;
+    data.push({
+      date: daysAgoIso(i),
+      count: DAILY_PATTERN[idx % DAILY_PATTERN.length],
+    });
+  }
+  return data;
+}
+
+export const DEMO_DIGEST = {
+  status: "draft",
+  period_start: daysAgoIso(29),
+  period_end: daysAgoIso(0),
+  feedback_count: 23,
+  summary:
+    "Customers love the coffee quality and the personal service — the cold brew and the counter staff come up again and again. " +
+    "The clearest friction point is weekend morning wait times, followed by pastries selling out early and a handful of comfort issues " +
+    "(wobbly patio tables, spotty Wi-Fi). Several regulars asked for oat milk. Overall sentiment is strongly positive, with the most " +
+    "actionable requests concentrated on weekend capacity and morning stock.",
+  insights: [
+    "Cold brew and barista friendliness are your biggest strengths — mentioned in over half of submissions.",
+    "Saturday and Sunday morning wait times are the #1 complaint, with several customers saying they've left without ordering.",
+    "Pastries regularly sell out before 10am, disappointing late-morning regulars.",
+    "Small comfort issues (wobbly patio tables, spotty Wi-Fi) are quietly hurting the work-from-café crowd.",
+  ],
+  immediate_actions: [
+    "Add a second register or a dedicated mobile-order pickup lane on weekend mornings.",
+    "Increase the Saturday pastry order, starting with the almond croissants that sell out first.",
+    "Tighten or replace the wobbly patio tables — a five-minute fix customers keep noticing.",
+  ],
+  long_term_goals: [
+    "Pilot oat milk and other alternative milks this quarter — the most requested menu addition.",
+    "Upgrade the Wi-Fi to keep laptop customers around during slow weekday afternoons.",
+    "Build a loyalty program around the regulars who already praise the punch card.",
+  ],
+};
+
+export const DEMO_MEMBERS = [
+  { email: "you@magnoliaroux.com", role: "admin", joined: "Jan 2026", isSelf: true },
+  { email: "renee@magnoliaroux.com", role: "viewer", joined: "Feb 2026" },
+  { email: "marcus@magnoliaroux.com", role: "viewer", joined: "Mar 2026" },
+];
+
+export const DEMO_STEPS = [
+  {
+    id: "intro",
+    kicker: "The demo",
+    caption: "A 60-second tour of five* — first as your customer, then as you.",
+    url: "fivestar.la",
+  },
+  {
+    id: "search",
+    kicker: "Customer view",
+    caption: "Your customer searches for your business — no account, no app.",
+    url: "fivestar.la/search",
+  },
+  {
+    id: "feedback",
+    kicker: "Customer view",
+    caption: "They write honest, private feedback. It goes to you — not to the internet.",
+    url: "fivestar.la/feedback/magnolia-roux",
+  },
+  {
+    id: "boost",
+    kicker: "Customer view",
+    caption:
+      "Then five* nudges them to post publicly too — on the platforms you choose. It never pulls reviews away from Google or Yelp.",
+    url: "fivestar.la/feedback/magnolia-roux",
+  },
+  {
+    id: "flip",
+    kicker: "Switching sides",
+    caption: "That took your customer about 30 seconds. Now see what you get.",
+    url: "fivestar.la/dashboard",
+  },
+  {
+    id: "dashboard",
+    kicker: "Owner view",
+    caption: "Every submission lands on your private dashboard. One click turns them into a report.",
+    url: "fivestar.la/dashboard",
+  },
+  {
+    id: "formats",
+    kicker: "Owner view",
+    caption: "Same report, your format — bullets, an action plan, or a ready-to-send email.",
+    url: "fivestar.la/dashboard",
+  },
+  {
+    id: "share",
+    kicker: "Owner view",
+    caption: "Publish the report and your whole team sees the same priorities.",
+    url: "fivestar.la/dashboard",
+  },
+];

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -734,6 +734,11 @@ select {
   background: rgba(255, 255, 255, 0.9);
 }
 
+.digest-flow-marker {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
 
 .marketing-cta-band {
   padding: clamp(1.7rem, 4vw, 2.5rem);
@@ -1599,4 +1604,635 @@ select {
 .review-another-btn {
   margin-top: 0.5rem;
   align-self: flex-start;
+}
+
+/* ── Homepage interactive demo ─────────────────────────────────────────── */
+
+html {
+  scroll-behavior: smooth;
+}
+
+.home-demo {
+  scroll-margin-top: 96px;
+}
+
+/* Caption bar */
+.home-demo-captionbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.demo-kicker-chip {
+  flex-shrink: 0;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: var(--color-ink);
+  color: var(--color-bg);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.demo-caption {
+  margin: 0;
+  flex: 1;
+  min-width: 220px;
+  font-size: 0.92rem;
+  color: var(--color-text);
+}
+
+.demo-step-count {
+  flex-shrink: 0;
+  font-size: 0.82rem;
+  color: var(--color-muted);
+  font-weight: 600;
+}
+
+/* Browser-style frame */
+.home-demo-frame {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 18px 40px rgba(24, 57, 43, 0.1);
+}
+
+.home-demo-chrome {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  background: var(--color-ink);
+}
+
+.home-demo-chrome-dots {
+  display: flex;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.home-demo-chrome-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.home-demo-url {
+  flex: 1;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--color-bg);
+  border-radius: 8px;
+  padding: 0.3rem 0.7rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Stage */
+.home-demo-stage {
+  min-height: 460px;
+  padding: 1.75rem 1.25rem;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.demo-screen {
+  width: 100%;
+  max-width: 600px;
+  animation: demo-step-in 0.28s ease;
+}
+
+.demo-screen--wide {
+  max-width: 680px;
+}
+
+.home-demo-stage--flip .demo-screen {
+  animation: demo-flip-in 0.5s ease;
+}
+
+@keyframes demo-step-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes demo-flip-in {
+  from {
+    opacity: 0;
+    transform: perspective(900px) rotateY(8deg);
+  }
+  to {
+    opacity: 1;
+    transform: perspective(900px) rotateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  .demo-screen,
+  .home-demo-stage--flip .demo-screen {
+    animation: none;
+  }
+}
+
+/* Controls */
+.home-demo-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.demo-dots {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.demo-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  background: var(--color-border);
+  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.demo-dot:hover {
+  transform: scale(1.25);
+}
+
+.demo-dot--active {
+  background: var(--color-primary);
+}
+
+.demo-controls-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.demo-restart {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.demo-restart:hover {
+  color: var(--color-ink);
+}
+
+/* Shared demo bits */
+.demo-note {
+  font-size: 0.82rem;
+  color: var(--color-muted);
+  margin: 0.5rem 0 0;
+}
+
+/* Intro / flip interstitial */
+.demo-inter-card {
+  text-align: center;
+  padding: 3.5rem 1.5rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.demo-inter-title {
+  font-family: var(--font-serif);
+  font-size: 1.6rem;
+  color: var(--color-ink);
+  margin: 0.5rem 0 0.75rem;
+}
+
+.demo-inter-copy {
+  color: var(--color-muted);
+  line-height: 1.6;
+  margin: 0 0 1.5rem;
+}
+
+/* Compact overrides for real classes inside the frame */
+.home-demo-stage .search-container {
+  padding: 0;
+}
+
+.home-demo-stage .search-title {
+  font-size: 1.5rem;
+}
+
+.home-demo-stage .feedback-card {
+  box-shadow: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+  max-width: 100%;
+}
+
+.home-demo-stage .feedback-title {
+  font-size: 1.5rem;
+}
+
+.home-demo-stage .feedback-subtitle {
+  margin-bottom: 1.25rem;
+}
+
+.home-demo-stage .feedback-optional {
+  padding: 1rem;
+  margin-top: 0.25rem;
+}
+
+.home-demo-stage .btn--large {
+  padding: 0.8rem 1.6rem;
+  font-size: 1rem;
+  margin-top: 0.25rem;
+}
+
+.demo-use-original {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.82rem;
+  color: var(--color-primary);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.demo-polish-active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.demo-platform-note {
+  color: #1a7a3a;
+  font-weight: 600;
+}
+
+/* Owner dashboard screens */
+.demo-dash-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.demo-dash-title {
+  font-family: var(--font-serif);
+  font-size: 1.35rem;
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.demo-owner-pill {
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(214, 106, 61, 0.12);
+  color: var(--color-primary);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.demo-dash-panel {
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 1.25rem;
+}
+
+.demo-dash-heading {
+  margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+  color: var(--color-ink);
+}
+
+.demo-dash-meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.88rem;
+  color: var(--color-muted);
+}
+
+.demo-horizon-row {
+  margin-bottom: 0.75rem;
+}
+
+.demo-horizon-pill {
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.demo-generate-row {
+  margin-top: 0.5rem;
+}
+
+.demo-generate-row .demo-dash-meta {
+  margin-top: 0.5rem;
+}
+
+.demo-recent-list {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.demo-recent-item {
+  background: #fafcfd;
+  border: 1px solid #e3eaf0;
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.88rem;
+}
+
+.demo-recent-item p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.demo-recent-item--yours {
+  border-color: rgba(214, 106, 61, 0.45);
+  background: rgba(214, 106, 61, 0.05);
+}
+
+.demo-recent-meta {
+  margin-top: 0.3rem !important;
+  font-size: 0.76rem;
+  color: var(--color-muted);
+}
+
+.demo-recent-badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 6px;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+/* Digest card */
+.demo-digest-card {
+  border: 1px solid #d6dfe6;
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.demo-digest-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.8rem 1rem;
+  flex-wrap: wrap;
+}
+
+.demo-badge {
+  padding: 0.15rem 0.55rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.demo-badge--draft {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.demo-badge--published {
+  background: #e0f7ea;
+  color: #1a7a3a;
+}
+
+.demo-digest-period {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #2d1b42;
+}
+
+.demo-digest-count {
+  font-size: 0.82rem;
+  color: #5e6770;
+}
+
+.demo-digest-body {
+  padding: 1rem;
+  border-top: 1px solid #f0f3f6;
+}
+
+.demo-digest-view {
+  display: grid;
+  gap: 1rem;
+}
+
+.demo-digest-label {
+  margin: 0 0 0.4rem;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: #4f5a66;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.demo-digest-summary {
+  margin: 0;
+  line-height: 1.6;
+  font-size: 0.92rem;
+}
+
+.demo-digest-summary-only {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  color: var(--color-ink-soft);
+}
+
+.demo-digest-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  font-size: 0.92rem;
+}
+
+.demo-digest-list li {
+  line-height: 1.6;
+  margin-bottom: 0.25rem;
+}
+
+.demo-check-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.92rem;
+}
+
+.demo-check-list li {
+  line-height: 1.5;
+}
+
+.demo-check-box {
+  color: var(--color-primary);
+  margin-right: 0.2rem;
+}
+
+/* Format pills */
+.demo-format-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.demo-format-pill {
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.demo-format-pill:hover {
+  border-color: var(--color-ink);
+  color: var(--color-ink);
+}
+
+.demo-format-pill--active {
+  background: var(--color-ink);
+  border-color: var(--color-ink);
+  color: var(--color-bg);
+}
+
+/* Email format */
+.demo-email-preview {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.demo-email-head {
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid #f0f3f6;
+  font-size: 0.84rem;
+  color: var(--color-muted);
+}
+
+.demo-email-head p {
+  margin: 0 0 0.2rem;
+}
+
+.demo-email-body {
+  padding: 0.9rem;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.demo-email-body p {
+  margin: 0 0 0.75rem;
+}
+
+.demo-email-body ol {
+  margin: 0 0 0.75rem;
+  padding-left: 1.3rem;
+}
+
+/* Share step */
+.demo-btn-share {
+  background: #1a7a3a;
+  color: #fff;
+  border: 1px solid transparent;
+}
+
+.demo-btn-share:hover {
+  background: #14602e;
+}
+
+.demo-share-row {
+  margin-top: 1rem;
+}
+
+.demo-team-panel {
+  margin-top: 1.25rem;
+}
+
+.demo-table-scroll {
+  overflow-x: auto;
+}
+
+.demo-share-finale {
+  margin: 1rem 0 0;
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  color: var(--color-ink);
+}
+
+/* Responsive */
+@media (max-width: 760px) {
+  .home-demo-stage {
+    padding: 1.25rem 0.9rem;
+    min-height: 420px;
+  }
+
+  .home-demo-captionbar {
+    align-items: flex-start;
+  }
+
+  .demo-caption {
+    order: 3;
+    flex-basis: 100%;
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-dots {
+    display: none;
+  }
+
+  .home-demo-controls {
+    justify-content: space-between;
+  }
+
+  .demo-dash-panel {
+    padding: 1rem 0.8rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Adds a click-through demo section on the homepage (no separate page) that walks a prospective business owner through the whole loop: customer search → feedback page → submit review → public-review nudge (Google/Yelp links, business-configured) → owner dashboard → AI report shown in five formats → publish/share with team → signup CTA. Fully client-side, zero API calls.
- Extracts the submissions chart out of `DigestManager` into a reusable `SubmissionsChart` component so the demo and the real dashboard share the same chart code.
- Copy pass across the marketing homepage: clearer benefit bullets, sharper pain-point language, and renaming "digest" to "report" (both on the homepage and in the demo) since "digest" read as jargon to a non-technical business owner. The signed-in dashboard/backend still use "digest" internally — not touched in this PR.

## Test plan
- [x] `npm run build` passes
- [x] Full demo clickthrough (search → feedback → public boost → dashboard → formats → share) verified in browser, including jumping between steps via the progress dots
- [x] Verified zero network requests fire from the demo
- [x] Verified new/changed marketing copy renders as expected
- [x] Checked mobile viewport (375px) for the demo section

🤖 Generated with [Claude Code](https://claude.com/claude-code)