### PR TITLE
Address homepage copy and demo UX feedback

### DIFF
--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -77,8 +77,8 @@ export default function MarketingPage() {
           </h1>
           <p className="marketing-copy">
             Your customers want you to succeed. They just need a way to tell you
-            what&apos;s working and what isn&apos;t. five* gives them that channel
-            and gives you a clear summary of what to do next.
+            what&apos;s working &mdash; and what isn&apos;t. <strong>five*</strong> gives them that
+            channel and gives you a clear summary of what to do next.
           </p>
 
           <div className="marketing-actions">

--- a/frontend/src/components/demo/HomeDemo.jsx
+++ b/frontend/src/components/demo/HomeDemo.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import DemoSearchScreen from "./DemoSearchScreen";
 import DemoFeedbackScreen from "./DemoFeedbackScreen";
@@ -14,9 +14,23 @@ export default function HomeDemo() {
   const [digestGenerated, setDigestGenerated] = useState(false);
   const [digestPublished, setDigestPublished] = useState(false);
   const [digestFormat, setDigestFormat] = useState("full");
+  const frameRef = useRef(null);
+  const hasMounted = useRef(false);
 
   const step = DEMO_STEPS[stepIndex];
   const isLast = stepIndex === DEMO_STEPS.length - 1;
+
+  // Screens vary a lot in height (e.g. the share screen starts short, then
+  // grows once published). Re-anchor to the top of the frame on every step
+  // change so a shrinking screen never leaves the viewport scrolled past
+  // the part the user is meant to see.
+  useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+    frameRef.current?.scrollIntoView({ block: "start" });
+  }, [stepIndex]);
 
   function goTo(index) {
     // Keep later steps consistent even if scripted actions were skipped
@@ -129,7 +143,7 @@ export default function HomeDemo() {
         <span className="demo-step-count">Step {stepIndex + 1} of {DEMO_STEPS.length}</span>
       </div>
 
-      <div className="home-demo-frame">
+      <div className="home-demo-frame" ref={frameRef}>
         <div className="home-demo-chrome">
           <span className="home-demo-chrome-dots" aria-hidden="true">
             <span className="home-demo-chrome-dot" />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -593,6 +593,11 @@ select {
   font-size: 1.08rem;
 }
 
+.marketing-copy strong {
+  color: var(--color-ink);
+  font-weight: 700;
+}
+
 .marketing-actions {
   display: flex;
   gap: 0.8rem;
@@ -1659,6 +1664,7 @@ html {
   border-radius: 18px;
   overflow: hidden;
   box-shadow: 0 18px 40px rgba(24, 57, 43, 0.1);
+  scroll-margin-top: 96px;
 }
 
 .home-demo-chrome {
@@ -1747,6 +1753,9 @@ html {
   }
   .demo-screen,
   .home-demo-stage--flip .demo-screen {
+    animation: none;
+  }
+  .demo-format-pills {
     animation: none;
   }
 }
@@ -2115,7 +2124,22 @@ html {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
-  margin-bottom: 1rem;
+  margin: -0.4rem -0.4rem 0.6rem;
+  padding: 0.4rem;
+  border-radius: 12px;
+  animation: demo-format-pills-highlight 1.6s ease;
+}
+
+@keyframes demo-format-pills-highlight {
+  0%,
+  65% {
+    background: rgba(214, 106, 61, 0.14);
+    box-shadow: 0 0 0 4px rgba(214, 106, 61, 0.14);
+  }
+  100% {
+    background: transparent;
+    box-shadow: 0 0 0 0 rgba(214, 106, 61, 0);
+  }
 }
 
 .demo-format-pill {


### PR DESCRIPTION
## Summary

Addresses four pieces of homepage feedback:

1. **Hero copy** — "…tell you what's working — and what isn't." The em dash sets the closing clause apart as intended.
2. **five\* visibility** — the brand mention in the hero paragraph is now bold and rendered in the dark ink color so it no longer hides mid-sentence.
3. **Demo screens 6→7** — when the report-formats step appears, the format pill row flashes a brief highlight glow so the new controls are obvious (disabled under `prefers-reduced-motion`).
4. **Demo screen 8 scroll position** — the demo re-anchors the frame to the top of the viewport on every step change, so a shorter screen can never leave the viewer scrolled past the content they're meant to see.

## Testing

- Clicked through all 8 demo steps in the browser preview; verified the highlight fires on the 6→7 transition and the scroll re-anchor fires on 6→7 and 7→8
- Verified hero copy rendering (em dash + bold five*) visually
- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)