### PR TITLE
Update default sender email to fivestar.fyi domain

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     frontend_origin: str = "http://localhost:5173"
     openai_api_key: str = ""
     sendgrid_api_key: str = ""
-    sender_email: str = "noreply@fivestarfeedback.app"
+    sender_email: str = "noreply@fivestar.fyi"
     app_base_url: str = "http://localhost:5173"
     rate_limit_enabled: bool = True
     sentry_dsn: str = ""


### PR DESCRIPTION
## Summary
- Investigated why password-reset emails weren't reaching the inbox: `SENDER_EMAIL` was set to the user's personal iCloud address, so SendGrid mail failed DMARC alignment at iCloud and was silently dropped/junked.
- Registered `fivestar.fyi`, set up Google Workspace (MX/SPF/DKIM), added Fly TLS certs, and completed SendGrid domain authentication for `fivestar.fyi`.
- Flipped the live `APP_BASE_URL`, `FRONTEND_ORIGIN`, and `SENDER_EMAIL` Fly secrets to the new domain, and confirmed a real password-reset email now delivers.
- This PR just brings the code default in line with what's now deployed — the old default (`noreply@fivestarfeedback.app`) pointed at a domain that was never registered.

## Test plan
- [x] Verified DNS (A/AAAA/CNAME) resolves for fivestar.fyi
- [x] Verified Fly certs issued for apex + www
- [x] Verified SendGrid domain authentication valid
- [x] Triggered a live `/auth/forgot-password` call and confirmed `delivered` status in SendGrid Messages API, landing in the real inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)