### PR TITLE
Refine homepage demo and mobile interactions

### DIFF
--- a/frontend/src/components/MarketingPage.jsx
+++ b/frontend/src/components/MarketingPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Ban, Inbox, Mail, Megaphone, MessageCircleQuestion } from "lucide-react";
 import { Link } from "react-router-dom";
 import BrandName, { BrandedText } from "./BrandName";
@@ -196,9 +196,52 @@ const WHY_FIVE_PHOTOS = [
 
 export default function MarketingPage() {
   const [whyFivePhotoIndex, setWhyFivePhotoIndex] = useState(0);
+  const whyFiveSwipeRef = useRef(null);
+  const whyFiveSuppressClickRef = useRef(false);
 
-  function cycleWhyFivePhoto() {
-    setWhyFivePhotoIndex((index) => (index + 1) % WHY_FIVE_PHOTOS.length);
+  function cycleWhyFivePhoto(direction = 1) {
+    setWhyFivePhotoIndex(
+      (index) => (index + direction + WHY_FIVE_PHOTOS.length) % WHY_FIVE_PHOTOS.length
+    );
+  }
+
+  function handleWhyFivePointerDown(event) {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+
+    whyFiveSwipeRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+    };
+  }
+
+  function handleWhyFivePointerUp(event) {
+    const swipe = whyFiveSwipeRef.current;
+    whyFiveSwipeRef.current = null;
+
+    if (!swipe || swipe.pointerId !== event.pointerId) return;
+
+    const deltaX = event.clientX - swipe.x;
+    const deltaY = event.clientY - swipe.y;
+    const isHorizontalSwipe = Math.abs(deltaX) >= 44 && Math.abs(deltaX) > Math.abs(deltaY);
+
+    if (!isHorizontalSwipe) return;
+
+    whyFiveSuppressClickRef.current = true;
+    cycleWhyFivePhoto(deltaX < 0 ? 1 : -1);
+
+    window.setTimeout(() => {
+      whyFiveSuppressClickRef.current = false;
+    }, 0);
+  }
+
+  function handleWhyFiveClick() {
+    if (whyFiveSuppressClickRef.current) {
+      whyFiveSuppressClickRef.current = false;
+      return;
+    }
+
+    cycleWhyFivePhoto();
   }
 
   return (
@@ -246,9 +289,9 @@ export default function MarketingPage() {
         <div className="silent-majority-layout">
           <div className="constructive-chart" aria-label="Feedback channels ranked by useful context">
             <div className="constructive-context-scale" aria-hidden="true">
-              <span className="constructive-context-label">More useful context</span>
+              <span className="constructive-context-label">More useful</span>
               <span className="constructive-context-track" />
-              <span className="constructive-context-label">Less useful context</span>
+              <span className="constructive-context-label">Less useful</span>
             </div>
 
             <div className="constructive-stack">
@@ -406,10 +449,12 @@ export default function MarketingPage() {
             className="why-five-figure"
             role="button"
             tabIndex={0}
-            aria-label="Cycle through five-star placement photos"
-            onClick={cycleWhyFivePhoto}
-            onPointerEnter={(event) => {
-              if (event.pointerType === "mouse") cycleWhyFivePhoto();
+            aria-label={`Placement photo ${whyFivePhotoIndex + 1} of ${WHY_FIVE_PHOTOS.length}. Swipe left or right, or activate, to change photo.`}
+            onClick={handleWhyFiveClick}
+            onPointerDown={handleWhyFivePointerDown}
+            onPointerUp={handleWhyFivePointerUp}
+            onPointerCancel={() => {
+              whyFiveSwipeRef.current = null;
             }}
             onKeyDown={(event) => {
               if (event.key === "Enter" || event.key === " ") {
@@ -429,6 +474,7 @@ export default function MarketingPage() {
                     src={photo.src}
                     alt={position === 0 ? photo.alt : ""}
                     aria-hidden={position === 0 ? undefined : "true"}
+                    draggable="false"
                     style={{ objectPosition: photo.objectPosition }}
                   />
                 );

--- a/frontend/src/components/demo/DemoDashboardScreen.jsx
+++ b/frontend/src/components/demo/DemoDashboardScreen.jsx
@@ -112,11 +112,6 @@ export default function DemoDashboardScreen({ focus, digestGenerated, onGenerate
           </DemoDigestCard>
         )}
 
-        {showFormats && (
-          <p className="demo-note">
-            One report, five ways to read it — try the formats above. You can also edit any line before sharing.
-          </p>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/components/demo/DemoFeedbackScreen.jsx
+++ b/frontend/src/components/demo/DemoFeedbackScreen.jsx
@@ -65,7 +65,6 @@ function FeedbackForm({ onSubmitted }) {
         <button className="btn btn--primary btn--large" type="submit" disabled={isSubmitting}>
           {isSubmitting ? "Submitting..." : "Submit Feedback"}
         </button>
-        <p className="demo-note">We prefilled this one for you — edit it if you like, then hit submit.</p>
       </form>
     </div>
   );
@@ -175,9 +174,6 @@ function ShareBoost({ draft, onDraftChange }) {
         ) : (
           <p className="review-share-hint">Clicking a platform copies your draft automatically.</p>
         )}
-        <p className="demo-note">
-          These links are set by the business — you pick which platforms to send your customers to.
-        </p>
       </div>
     </div>
   );

--- a/frontend/src/components/demo/DemoSearchScreen.jsx
+++ b/frontend/src/components/demo/DemoSearchScreen.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { DEMO_ORG, DEMO_SEARCH_RESULTS } from "./demoData";
+import { DEMO_SEARCH_RESULTS } from "./demoData";
 
 export default function DemoSearchScreen({ onSelect }) {
   const [query, setQuery] = useState("magnolia");
@@ -45,9 +45,6 @@ export default function DemoSearchScreen({ onSelect }) {
                 </li>
               ))}
             </ul>
-            <p className="demo-note">
-              Click <strong>{DEMO_ORG.name}</strong> to leave them feedback.
-            </p>
           </div>
         ) : (
           <p className="search-no-results">

--- a/frontend/src/components/demo/DemoShareScreen.jsx
+++ b/frontend/src/components/demo/DemoShareScreen.jsx
@@ -44,7 +44,6 @@ export default function DemoShareScreen({ published, onPublish }) {
                 >
                   {isPublishing ? "Publishing…" : "Share with Organization"}
                 </button>
-                <p className="demo-note">Publishing makes the report visible to everyone on your team.</p>
               </div>
             )}
           </div>

--- a/frontend/src/components/demo/HomeDemo.jsx
+++ b/frontend/src/components/demo/HomeDemo.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { MousePointerClick, Pause, Play } from "lucide-react";
 import { Link } from "react-router-dom";
 import BrandName from "../BrandName";
 import DemoSearchScreen from "./DemoSearchScreen";
@@ -8,6 +9,7 @@ import DemoShareScreen from "./DemoShareScreen";
 import { DEMO_ORG, DEMO_PREFILLED_REVIEW, DEMO_STEPS } from "./demoData";
 
 const DASHBOARD_STEP = 5; // index of the owner-dashboard step
+const PLAYBACK_DELAY_MS = 5000;
 
 export default function HomeDemo() {
   const [stepIndex, setStepIndex] = useState(0);
@@ -15,6 +17,8 @@ export default function HomeDemo() {
   const [digestGenerated, setDigestGenerated] = useState(false);
   const [digestPublished, setDigestPublished] = useState(false);
   const [digestFormat, setDigestFormat] = useState("full");
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackMode, setPlaybackMode] = useState(false);
   const frameRef = useRef(null);
   const previousStepIndex = useRef(stepIndex);
 
@@ -32,18 +36,55 @@ export default function HomeDemo() {
     frameRef.current?.scrollIntoView({ block: "start" });
   }, [stepIndex]);
 
+  useEffect(() => {
+    if (!isPlaying || isLast) return undefined;
+
+    const timeoutId = window.setTimeout(() => {
+      const nextIndex = stepIndex + 1;
+
+      if (nextIndex > DASHBOARD_STEP) setDigestGenerated(true);
+      if (nextIndex === DEMO_STEPS.length - 1) {
+        setDigestPublished(true);
+        setIsPlaying(false);
+        setPlaybackMode(false);
+      }
+
+      setStepIndex(nextIndex);
+    }, PLAYBACK_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [isLast, isPlaying, stepIndex]);
+
   function goTo(index) {
+    setIsPlaying(false);
+    setPlaybackMode(false);
     // Keep later steps consistent even if scripted actions were skipped
     if (index > DASHBOARD_STEP) setDigestGenerated(true);
     setStepIndex(Math.max(0, Math.min(index, DEMO_STEPS.length - 1)));
   }
 
   function restart() {
+    setIsPlaying(false);
+    setPlaybackMode(false);
     setStepIndex(0);
     setDraft(DEMO_PREFILLED_REVIEW.text);
     setDigestGenerated(false);
     setDigestPublished(false);
     setDigestFormat("full");
+  }
+
+  function startPlayback() {
+    setStepIndex(1);
+    setDraft(DEMO_PREFILLED_REVIEW.text);
+    setDigestGenerated(false);
+    setDigestPublished(false);
+    setDigestFormat("full");
+    setPlaybackMode(true);
+    setIsPlaying(true);
+  }
+
+  function togglePlayback() {
+    setIsPlaying((playing) => !playing);
   }
 
   function renderStep() {
@@ -59,9 +100,15 @@ export default function HomeDemo() {
                 <strong>{DEMO_ORG.name}</strong>, a (fictional) café in {DEMO_ORG.city}. Then
                 you&apos;ll switch sides and see exactly what the owner gets.
               </p>
-              <button type="button" className="btn btn--primary" onClick={() => goTo(1)}>
-                Start the demo →
-              </button>
+              <div className="demo-start-actions">
+                <button type="button" className="btn btn--primary" onClick={() => goTo(1)}>
+                  Start interactive demo →
+                </button>
+                <button type="button" className="demo-autoplay-start" onClick={startPlayback}>
+                  <Play size={15} fill="currentColor" aria-hidden="true" />
+                  Play automatically
+                </button>
+              </div>
             </div>
           </div>
         );
@@ -133,69 +180,98 @@ export default function HomeDemo() {
         <h2 className="section-title">See the whole loop in 60 seconds.</h2>
       </div>
 
-      <div className="home-demo-captionbar">
-        <span className="demo-kicker-chip">{step.kicker}</span>
-        <span className="demo-step-count">Step {stepIndex + 1} of {DEMO_STEPS.length}</span>
+      <div className="home-demo-experience" ref={frameRef}>
+        {stepIndex > 0 && (
+          <div className="demo-guidance">
+            <div className="demo-guidance-content">
+              <p className="demo-guidance-label">
+                {playbackMode ? (
+                  <Play size={14} fill="currentColor" aria-hidden="true" />
+                ) : (
+                  <MousePointerClick size={14} aria-hidden="true" />
+                )}
+                {playbackMode
+                  ? isPlaying
+                    ? "Playing automatically"
+                    : "Autoplay paused"
+                  : "Demo guide"}
+              </p>
+              <p className="demo-guidance-copy" aria-live="polite">
+                {playbackMode || (step.id === "share" && digestPublished)
+                  ? step.caption
+                  : step.guidance}
+              </p>
+            </div>
+            {playbackMode && (
+              <button
+                type="button"
+                className="demo-playback-control"
+                onClick={togglePlayback}
+                aria-label={isPlaying ? "Pause autoplay" : "Resume autoplay"}
+              >
+                {isPlaying ? (
+                  <Pause size={15} aria-hidden="true" />
+                ) : (
+                  <Play size={15} fill="currentColor" aria-hidden="true" />
+                )}
+                {isPlaying ? "Pause" : "Resume"}
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="home-demo-frame">
+          <div className="home-demo-chrome">
+            <span className="home-demo-chrome-dots" aria-hidden="true">
+              <span className="home-demo-chrome-dot" />
+              <span className="home-demo-chrome-dot" />
+              <span className="home-demo-chrome-dot" />
+            </span>
+            <span className="home-demo-url">{step.url}</span>
+          </div>
+          <div
+            className={`home-demo-stage ${stepIndex === DASHBOARD_STEP ? "home-demo-stage--flip" : ""}`}
+            key={stepIndex}
+          >
+            {renderStep()}
+          </div>
+        </div>
       </div>
 
-      <div className="home-demo-frame" ref={frameRef}>
-        <div className="home-demo-chrome">
-          <span className="home-demo-chrome-dots" aria-hidden="true">
-            <span className="home-demo-chrome-dot" />
-            <span className="home-demo-chrome-dot" />
-            <span className="home-demo-chrome-dot" />
-          </span>
-          <span className="home-demo-url">{step.url}</span>
-        </div>
-        <div
-          className={`home-demo-stage ${stepIndex === DASHBOARD_STEP ? "home-demo-stage--flip" : ""}`}
-          key={stepIndex}
-        >
-          {renderStep()}
-        </div>
-      </div>
-
-      <div className="home-demo-controls">
-        <button
-          type="button"
-          className="btn btn--ghost btn--sm"
-          onClick={() => goTo(stepIndex - 1)}
-          disabled={stepIndex === 0}
-        >
-          ← Back
-        </button>
-
-        <div className="demo-dots" role="tablist" aria-label="Demo steps">
-          {DEMO_STEPS.map((s, i) => (
-            <button
-              key={s.id}
-              type="button"
-              className={`demo-dot ${i === stepIndex ? "demo-dot--active" : ""}`}
-              onClick={() => goTo(i)}
-              aria-label={`Go to step ${i + 1}`}
-            />
-          ))}
-        </div>
-
-        <div className="demo-controls-right">
-          <button type="button" className="demo-restart" onClick={restart}>
-            Restart
+      {stepIndex > 0 && (
+        <div className="home-demo-controls">
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm"
+            onClick={() => goTo(stepIndex - 1)}
+          >
+            ← Back
           </button>
-          {isLast ? (
-            <Link className="btn btn--primary btn--sm" to="/auth?mode=signup">
-              Get started
-            </Link>
-          ) : (
-            <button
-              type="button"
-              className="btn btn--primary btn--sm"
-              onClick={() => goTo(stepIndex + 1)}
-            >
-              Next →
+
+          <span className="demo-progress" aria-live="polite">
+            Step {stepIndex} of {DEMO_STEPS.length - 1}
+          </span>
+
+          <div className="demo-controls-right">
+            <button type="button" className="demo-restart" onClick={restart}>
+              Restart
             </button>
-          )}
+            {isLast ? (
+              <Link className="btn btn--primary btn--sm" to="/auth?mode=signup">
+                Get started
+              </Link>
+            ) : (
+              <button
+                type="button"
+                className="btn btn--primary btn--sm"
+                onClick={() => goTo(stepIndex + 1)}
+              >
+                Next →
+              </button>
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/components/demo/demoData.js
+++ b/frontend/src/components/demo/demoData.js
@@ -110,51 +110,50 @@ export const DEMO_MEMBERS = [
 export const DEMO_STEPS = [
   {
     id: "intro",
-    kicker: "The demo",
     caption: "A 60-second tour of five* — first as your customer, then as you.",
     url: "fivestar.fyi",
   },
   {
     id: "search",
-    kicker: "Customer view",
     caption: "Your customer searches for your business — no account, no app.",
+    guidance: "Select Magnolia Roux Coffee & Kitchen to continue.",
     url: "fivestar.fyi/search",
   },
   {
     id: "feedback",
-    kicker: "Customer view",
     caption: "They write honest, private feedback. It goes to you — not to the internet.",
+    guidance: "Review the prefilled feedback, edit it if you like, then submit it.",
     url: "fivestar.fyi/feedback/magnolia-roux",
   },
   {
     id: "boost",
-    kicker: "Customer view",
     caption:
       "Then five* nudges them to post publicly too — on the platforms you choose. It never pulls reviews away from Google or Yelp.",
+    guidance: "Try a writing style or copy the draft, then continue to the owner view.",
     url: "fivestar.fyi/feedback/magnolia-roux",
   },
   {
     id: "flip",
-    kicker: "Switching sides",
     caption: "That took your customer about 30 seconds. Now see what you get.",
+    guidance: "Switch to the owner dashboard to see where the feedback lands.",
     url: "fivestar.fyi/dashboard",
   },
   {
     id: "dashboard",
-    kicker: "Owner view",
     caption: "Every submission lands on your private dashboard. One click turns them into a report.",
+    guidance: "Generate the report, then continue to explore its formats.",
     url: "fivestar.fyi/dashboard",
   },
   {
     id: "formats",
-    kicker: "Owner view",
     caption: "Same report, your format — bullets, an action plan, or a ready-to-send email.",
+    guidance: "Choose a format to change how the same report is presented.",
     url: "fivestar.fyi/dashboard",
   },
   {
     id: "share",
-    kicker: "Owner view",
     caption: "Publish the report and your whole team sees the same priorities.",
+    guidance: "Share the report to reveal what the whole team sees.",
     url: "fivestar.fyi/dashboard",
   },
 ];

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -793,19 +793,20 @@ select {
   width: 3px;
   min-height: 7rem;
   margin: 0.65rem 0;
-  background: linear-gradient(to bottom, var(--color-primary), rgba(24, 57, 43, 0.22));
+  background: linear-gradient(to bottom, var(--color-ink), rgba(24, 57, 43, 0.22));
 }
 
 .constructive-context-track::before {
   content: "";
   position: absolute;
-  top: -0.15rem;
+  top: -0.55rem;
   left: 50%;
-  width: 0.65rem;
-  height: 0.65rem;
-  border-top: 2px solid var(--color-primary);
-  border-left: 2px solid var(--color-primary);
-  transform: translateX(-50%) rotate(45deg);
+  width: 0;
+  height: 0;
+  border-right: 0.4rem solid transparent;
+  border-bottom: 0.62rem solid var(--color-ink);
+  border-left: 0.4rem solid transparent;
+  transform: translateX(-50%);
 }
 
 .constructive-stack {
@@ -844,7 +845,11 @@ select {
 }
 
 .constructive-tier--high {
-  background: rgba(214, 106, 61, 0.08);
+  background: rgba(24, 57, 43, 0.08);
+}
+
+.constructive-tier--high .constructive-tier-kicker {
+  color: var(--color-ink);
 }
 
 .constructive-tier-kicker,
@@ -1162,6 +1167,7 @@ select {
   margin: 0;
   padding: 0 1.1rem 2rem 0.7rem;
   cursor: pointer;
+  touch-action: pan-y;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -1198,6 +1204,7 @@ select {
     filter 420ms ease,
     box-shadow 420ms ease;
   user-select: none;
+  -webkit-user-drag: none;
 }
 
 .why-five-image--position-0 {
@@ -2311,32 +2318,69 @@ html {
   scroll-margin-top: 96px;
 }
 
-/* Caption bar */
-.home-demo-captionbar {
+.home-demo-experience {
+  scroll-margin-top: 96px;
+}
+
+.demo-guidance {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0.9rem;
   margin-bottom: 0.75rem;
-  flex-wrap: wrap;
+  border: 1px solid rgba(24, 57, 43, 0.18);
+  border-left: 3px solid var(--color-primary);
+  border-radius: 8px;
+  background: rgba(255, 253, 247, 0.78);
 }
 
-.demo-kicker-chip {
-  flex-shrink: 0;
-  padding: 0.25rem 0.7rem;
-  border-radius: 999px;
-  background: var(--color-ink);
-  color: var(--color-bg);
-  font-size: 0.75rem;
-  font-weight: 700;
+.demo-guidance-content {
+  min-width: 0;
+}
+
+.demo-guidance-label,
+.demo-guidance-copy {
+  margin: 0;
+}
+
+.demo-guidance-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--color-primary);
+  font-size: 0.68rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
-.demo-step-count {
-  flex-shrink: 0;
-  font-size: 0.82rem;
-  color: var(--color-muted);
-  font-weight: 600;
+.demo-guidance-copy {
+  margin-top: 0.18rem;
+  color: var(--color-text);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.demo-playback-control {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.65rem;
+  border: 1px solid rgba(24, 57, 43, 0.2);
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-ink);
+  font-size: 0.76rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.demo-playback-control:hover,
+.demo-playback-control:focus-visible {
+  border-color: var(--color-ink);
+  background: rgba(24, 57, 43, 0.07);
 }
 
 /* Browser-style frame */
@@ -2347,7 +2391,6 @@ html {
   border-radius: 18px;
   overflow: hidden;
   box-shadow: 0 18px 40px rgba(24, 57, 43, 0.1);
-  scroll-margin-top: 96px;
 }
 
 .home-demo-chrome {
@@ -2445,41 +2488,28 @@ html {
 
 /* Controls */
 .home-demo-controls {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
   margin-top: 1rem;
-  flex-wrap: wrap;
 }
 
-.demo-dots {
-  display: flex;
-  gap: 0.45rem;
+.home-demo-controls > .btn {
+  justify-self: start;
 }
 
-.demo-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: none;
-  padding: 0;
-  background: var(--color-border);
-  cursor: pointer;
-  transition: background 150ms ease, transform 150ms ease;
-}
-
-.demo-dot:hover {
-  transform: scale(1.25);
-}
-
-.demo-dot--active {
-  background: var(--color-primary);
+.demo-progress {
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .demo-controls-right {
   display: flex;
   align-items: center;
+  justify-self: end;
   gap: 0.75rem;
 }
 
@@ -2496,13 +2526,6 @@ html {
 
 .demo-restart:hover {
   color: var(--color-ink);
-}
-
-/* Shared demo bits */
-.demo-note {
-  font-size: 0.82rem;
-  color: var(--color-muted);
-  margin: 0.5rem 0 0;
 }
 
 /* Intro / flip interstitial */
@@ -2524,6 +2547,33 @@ html {
   color: var(--color-muted);
   line-height: 1.6;
   margin: 0 0 1.5rem;
+}
+
+.demo-start-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.demo-autoplay-start {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.15rem 0;
+  border: 0;
+  border-bottom: 1px solid rgba(24, 57, 43, 0.28);
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 0.8rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.demo-autoplay-start:hover,
+.demo-autoplay-start:focus-visible {
+  border-bottom-color: var(--color-ink);
+  color: var(--color-ink);
 }
 
 /* Compact overrides for real classes inside the frame */
@@ -2920,19 +2970,23 @@ html {
     min-height: 420px;
   }
 
-  .home-demo-captionbar {
+  .home-demo > .section-header {
+    padding-inline: 0.85rem;
+  }
+
+  .demo-guidance {
     align-items: flex-start;
   }
 
 }
 
 @media (max-width: 560px) {
-  .demo-dots {
-    display: none;
+  .home-demo-controls {
+    gap: 0.65rem;
   }
 
-  .home-demo-controls {
-    justify-content: space-between;
+  .demo-controls-right {
+    gap: 0.5rem;
   }
 
   .demo-dash-panel {


### PR DESCRIPTION
## What changed

- Add touch swipe support to the listening-mark photo stack.
- Refine the useful-context chart labels, arrow, and positive color treatment.
- Split the homepage demo into explicit interactive and autoplay entry paths.
- Move step guidance outside the simulated app, add clear progress and playback controls, and hide navigation until the demo starts.
- Balance the Back and Next control sizing across desktop and mobile.

## Why

Mobile feedback exposed unclear demo hierarchy, missing touch behavior, and inconsistent visual signals. These changes make the experience easier to understand and operate without changing backend behavior.

## Validation

- `npm run build` (frontend)
- `backend/.venv/bin/pytest -q backend` (14 passed)
- Responsive browser checks at 409px and 747px
- Branch synced with the latest `origin/main` with no conflicts