### PR TITLE
Sync the design system to claude.ai/design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,68 @@
+# design-sync notes — five-star-frontend
+
+## What this repo actually syncs
+
+This app has **no component library**. All 17 React exports under `frontend/src/components/` are
+API-bound page screens (auth, dashboard, marketing, demo) — there is no `dist/`, no lib build
+target, no Storybook. Syncing them would put unbuildable screens in the design project.
+
+So the design system here is **the CSS plus the brand mark**: 51 tokens in `theme.css`, the class
+vocabulary in `styles.css`, and `BrandName`/`BrandedText` — the only genuinely reusable React in
+the repo. `frontend/src/design-system.js` is the public surface and exists solely for this sync;
+adding a component to the design system means exporting it there.
+
+The user chose this scope explicitly on the first run (2026-07-25): tokens + CSS + brand mark, no
+page components.
+
+## Repo-specific gotchas
+
+- **`--entry` must be `frontend/src/design-system.js`, not `./src/…`.** PKG_DIR is derived by
+  walking up from `dirname(resolve(--entry))` looking for a `package.json` with a `name`. A
+  root-relative `./src/...` resolves against the repo root, finds the wrong package, and fails with
+  `ENOENT <root>/src/package.json`. The tell that it picked the wrong package: the build banner
+  reports `five-star-frontend@0.0.0` instead of `@0.1.0`.
+- **`cssEntry` is copied verbatim, so relative `@import`s inside it will not resolve** from the
+  output dir. The app loads `theme.css` and `styles.css` as two separate imports; they have to be
+  **concatenated**, which is what `frontend/scripts/build-ds-css.mjs` (wired as `buildCmd`) does.
+  Order is load-bearing twice: theme first because `styles.css` reads its custom properties, and
+  theme's webfont `@import` must stay the very first statement or CSS drops it.
+- **Root-relative asset urls must be inlined.** `.brand-name-mark` masks
+  `url("/brand/five-star-asterisk.svg")`, which resolves against `public/` in the app but against
+  *nothing* in a design project — the asterisk would render invisible in every design built with
+  the system, with no error anywhere. `build-ds-css.mjs` rewrites any `url("/…")` that resolves
+  under `frontend/public/` into a base64 data URI (2 assets today). If a new brand asset is
+  referenced from CSS, it is handled automatically; if it lives outside `public/`, it is left alone
+  and will break silently.
+- **`@types/react` is not in `frontend/node_modules`**, so the build prints `[DTS_REACT]`. It is
+  non-blocking here only because `cfg.dtsPropsFor` hand-supplies both prop bodies. Adding a third
+  component means either installing `@types/react` or adding its props by hand too.
+- **`typescript` is not in the repo's node_modules either**, so validate skips the `.d.ts` parse
+  check. Installing `typescript` into `.ds-sync/` (alongside `playwright`) turns it back on.
+- Both components are `cardMode: "column"` — every cell is a full-width copy block, and in the
+  default multi-column grid the text clipped mid-word.
+
+## Known render warns
+
+- `[FONT_REMOTE] "Manrope", "Newsreader"` — **expected, leave it.** `theme.css` opens with a Google
+  Fonts `@import`, so the families load at runtime and nothing needs shipping. There *are* locally
+  vendored woff2 files at `marketing/social/shared/fonts/`, but that set deliberately omits
+  Newsreader's italic axis (the social kit wants the browser-synthesized italic), so wiring them via
+  `extraFonts` would be a downgrade, not a fix. Do not "resolve" this warn.
+
+## Re-sync risks
+
+- **The conventions doc is hand-written and will rot.** `.design-sync/conventions.md` enumerates
+  token names and class families read off `styles.css` on 2026-07-25. Tokens added or renamed in
+  `theme.css`, or a new primitive family in `styles.css`, will not show up there on their own —
+  re-read both files against the doc on any re-sync that follows real CSS churn.
+- **The page-scoped/primitive split is a judgement call, not a rule the code enforces.** The doc
+  lists `demo-*`, `marketing-*`, `auth-*` etc. as app screens and everything else as reusable. A new
+  class family lands on neither list until someone decides.
+- **Preview copy is transcribed from `MarketingPage.jsx`**, not imported from it. If the marketing
+  copy changes, the preview cells keep quoting the old wording — harmless, but they stop being
+  examples of live copy.
+- **The render check needs playwright + chromium**, installed into the gitignored `.ds-sync/`. A
+  fresh clone has neither: re-run `npm i playwright typescript` in `.ds-sync/` and
+  `npx playwright install chromium`, or validate fails `[RENDER_SKIPPED]`.
+- The webfonts are fetched from Google at render time, so the render check assumes network. Offline,
+  cards render in fallback faces and a font regression would not be visible.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,22 @@
+{
+  "projectId": "57c8084f-4afd-4ca0-af3f-3b3e558cbb8c",
+  "pkg": "five-star-frontend",
+  "globalName": "FiveStar",
+  "shape": "package",
+  "buildCmd": "node scripts/build-ds-css.mjs",
+  "srcDir": "src",
+  "cssEntry": ".ds-css/design-system.css",
+  "componentSrcMap": {
+    "BrandName": "src/components/BrandName.jsx",
+    "BrandedText": "src/components/BrandName.jsx"
+  },
+  "dtsPropsFor": {
+    "BrandName": "className?: string;",
+    "BrandedText": "children?: React.ReactNode;"
+  },
+  "readmeHeader": ".design-sync/conventions.md",
+  "overrides": {
+    "BrandName": { "cardMode": "column" },
+    "BrandedText": { "cardMode": "column" }
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,93 @@
+# Building with the five* design system
+
+**This design system is mostly CSS.** It ships two React components; everything else — layout,
+buttons, fields, panels, type — is a class vocabulary defined in `styles.css` on top of the tokens
+in `:root`. Build screens the way the app does: semantic HTML plus these classes. Reach for a token
+or a class before writing a new colour, radius, or shadow.
+
+## Type
+
+Two families, both loaded by `styles.css`:
+
+- `var(--font-sans)` — **Manrope**. Everything interface: body copy, labels, buttons, nav, the
+  wordmark. Weights 400/500/600/700/800. The brand leans hard on **800** for anything that carries
+  weight; 500–600 for running copy.
+- `var(--font-serif)` — **Newsreader**. Display only: page and section titles. Set with tight
+  leading and negative tracking (`line-height: 1.02`, `letter-spacing: -0.03em`) — that pairing is
+  the brand's whole typographic signature, so keep it when you use the serif.
+
+Never mix the serif into UI chrome, and never set a heading in Manrope where the page already has a
+Newsreader title — the contrast between the two is the hierarchy.
+
+## Colour
+
+Ink is the text colour, teal is the brand, and both are quiet. There is no bright accent.
+
+| Token | Use |
+|---|---|
+| `--color-ink` `#173c45` | headings, emphasised text |
+| `--color-ink-soft` `#2a5660` | labels, secondary headings |
+| `--color-text` `#304d4f` | body copy |
+| `--color-muted` `#6b7978` | supporting copy, captions |
+| `--color-primary` `#087c80` | the brand teal — primary actions, kickers, links |
+| `--color-primary-hover` / `--color-primary-soft` | hover state / tinted teal wash |
+| `--color-bg` `#fdfdfc` | page |
+| `--color-surface` `#ffffff`, `--color-surface-alt` / `-subtle` / `-muted` / `-tint` | cards and panels, warm-neutral steps down from white |
+| `--color-border` `#dedfdb`, `--color-border-muted` `#eceeeb` | hairlines |
+| `--color-on-dark` `#f5fafa` | text on an ink surface |
+| `--color-success` / `--color-warning` / `--color-danger` (+ `-bg`, `-hover`) | semantic states only |
+| `--color-disabled`, `--color-neutral*`, `--color-star-muted`, `--color-avatar` | supporting neutrals |
+
+`--color-danger` is for genuine problems, not emphasis. Most of the brand's expressive range comes
+from ink-on-warm-white with teal used sparingly.
+
+## Shape and elevation
+
+Radii step by role, so pick by what the thing *is* rather than by size:
+`--radius-sm` 8 · `--radius-control` 12 (inputs) · `--radius-card` 16 · `--radius-panel` 22 ·
+`--radius-section` 28 · `--radius-pill` 999 (buttons are always pills).
+
+Shadows are wide and very soft — `--shadow-control`, `--shadow-card`, `--shadow-soft`,
+`--shadow-overlay`. Don't hand-roll a `box-shadow`; the softness is part of the look.
+
+## The class vocabulary
+
+These are the reusable parts. Each is `block` plus `block--modifier`.
+
+- **`.btn`** — pill, Manrope 800, inline-flex with `gap` so an icon just works. Variants
+  `--primary` (teal, lifts on hover), `--ghost` (hairline outline), `--outline`, `--danger`; sizes
+  `--sm`, `--large`. `:disabled` is styled for you.
+- **`.field-label` / `.field-input` / `.field-textarea` / `.field-select`** — full-width controls
+  with a teal focus ring. `.inline-form` lays a field and a button out on one row.
+- **`.section-shell` / `.section-header` / `.section-kicker` / `.section-title` / `.section-copy`** —
+  the standard content block. The kicker is uppercase teal Manrope 800 with wide tracking; the title
+  is Newsreader. This trio is how nearly every section on the site opens.
+- **`.modal-backdrop` / `.modal-card` / `.modal-title` / `.modal-subtitle` / `.modal-close`** — dialogs.
+- **`.menu-wrap` / `.menu-panel(--open)` / `.menu-section` / `.menu-item` / `.menu-divider` /
+  `.menu-kicker`** — dropdown menus.
+- **`.tabs` / `.tab(--active)`** — tab strip.
+- **`.brand-lockup`**, and `.brand-name` / `.brand-name-mark` behind the `BrandName` component below.
+- **`.layout(--public)`**, `.message(--error)`, `.url-display` / `.url-input`.
+
+**Page-scoped families are not reusable parts.** `demo-*`, `marketing-*`, `public-*`, `auth-*`,
+`home-*`, `dashboard-*`, `comparison-*`, `review-*`, `search-*`, `digest-*`, `settings-*`,
+`invite-*`, `members-*`, `feedback-*`, `org-*`, `why-*`, `silent-*`, `problem-*`, `constructive-*`
+and `topbar-*` are the app's own screens. They ship in the stylesheet because it ships whole — read
+them for reference, but compose new work from the primitives above, not from a marketing-page class.
+
+## Components
+
+Only two, because only two carry brand meaning a class cannot express.
+
+- **`BrandName`** — renders `five*` with the real asterisk mark. It is `color: inherit` and
+  `font: inherit`, and the mark is sized in `em`, so it takes on whatever type it's placed in. Use it
+  anywhere the product is named in JSX. Never type `five*` as literal text.
+- **`BrandedText`** — takes a **plain string** and swaps every literal `five*` for a `BrandName`.
+  This is for brand copy that lives in data (content arrays, CMS strings) rather than in JSX. It
+  takes a string child, not markup.
+
+## Writing the name
+
+It is `five*`, lowercase, with the asterisk as a raised mark — never "Five Star", "5-star", or a
+literal `*` glyph in rendered copy. In prose the brand is a quiet noun: "five\* turns feedback into a
+report", not "The Five Star Platform™".

--- a/.design-sync/previews/BrandName.tsx
+++ b/.design-sync/previews/BrandName.tsx
@@ -1,0 +1,66 @@
+/* BrandName preview cells.
+
+   BrandName has no visual props of its own — it is `color: inherit` and
+   `font: inherit`, and the asterisk is sized in `em`. So the only useful
+   stories are CONTEXTS: the same component dropped into different type and
+   colour surroundings, proving the mark tracks whatever it is placed in.
+   The running-text and kicker cells are the real compositions from
+   MarketingPage.jsx. */
+
+import { BrandName } from "five-star-frontend";
+
+const sans = { fontFamily: "var(--font-sans)", color: "var(--color-text)" };
+
+export function Wordmark() {
+  return (
+    <div style={{ ...sans, display: "flex", alignItems: "baseline", gap: "2.5rem" }}>
+      <span style={{ fontSize: "3rem", fontWeight: 800, color: "var(--color-ink)" }}>
+        <BrandName />
+      </span>
+      <span style={{ fontSize: "1.5rem", fontWeight: 800, color: "var(--color-ink)" }}>
+        <BrandName />
+      </span>
+      <span style={{ fontSize: "0.83rem", fontWeight: 800, color: "var(--color-ink)" }}>
+        <BrandName />
+      </span>
+    </div>
+  );
+}
+
+export function InRunningText() {
+  return (
+    <p style={{ ...sans, margin: 0, maxWidth: "32rem", fontSize: "1.05rem", lineHeight: 1.75 }}>
+      Customers rarely tell you what is working — and what isn&apos;t.{" "}
+      <strong style={{ color: "var(--color-ink)" }}>
+        <BrandName />
+      </strong>{" "}
+      helps you see the patterns in what they actually say.
+    </p>
+  );
+}
+
+export function SectionKicker() {
+  return (
+    <p className="section-kicker" style={{ margin: 0, fontFamily: "var(--font-sans)" }}>
+      Why <BrandName />
+    </p>
+  );
+}
+
+export function OnDarkSurface() {
+  return (
+    <div
+      style={{
+        background: "var(--color-ink)",
+        color: "var(--color-on-dark)",
+        padding: "2rem 2.25rem",
+        borderRadius: "var(--radius-panel)",
+        fontFamily: "var(--font-sans)",
+        fontSize: "1.75rem",
+        fontWeight: 800,
+      }}
+    >
+      <BrandName />
+    </div>
+  );
+}

--- a/.design-sync/previews/BrandedText.tsx
+++ b/.design-sync/previews/BrandedText.tsx
@@ -1,0 +1,69 @@
+/* BrandedText preview cells.
+
+   BrandedText takes a plain string and swaps every literal "five*" for a real
+   <BrandName />. It exists so brand copy can live in data — arrays of steps,
+   CMS strings, anything not authored as JSX — and still render the wordmark
+   correctly. The stories are therefore about the INPUT string, not props.
+   The copy is verbatim from the marketing page's own content arrays. */
+
+import { BrandedText } from "five-star-frontend";
+
+const copy = {
+  margin: 0,
+  maxWidth: "34rem",
+  fontFamily: "var(--font-sans)",
+  fontSize: "1.05rem",
+  lineHeight: 1.75,
+  color: "var(--color-muted)",
+};
+
+export function InlineInCopy() {
+  return (
+    <p style={copy}>
+      <BrandedText>
+        five* converts those submissions into an insight-driven report with a summary, clear themes,
+        and practical next steps.
+      </BrandedText>
+    </p>
+  );
+}
+
+export function SeveralMentions() {
+  return (
+    <p style={copy}>
+      <BrandedText>
+        A five* link goes on the counter. What customers leave there stays private, and five* turns
+        it into the report you read on Monday.
+      </BrandedText>
+    </p>
+  );
+}
+
+export function NoMention() {
+  return (
+    <p style={copy}>
+      <BrandedText>
+        Copy with no brand token passes through untouched — safe to wrap every string in a content
+        array.
+      </BrandedText>
+    </p>
+  );
+}
+
+export function FromDataArray() {
+  const steps = [
+    "Share your five* link wherever customers already are.",
+    "They answer in under a minute, privately.",
+    "five* groups the answers into themes you can act on.",
+  ];
+
+  return (
+    <ol style={{ ...copy, paddingLeft: "1.25rem", display: "grid", gap: "0.6rem" }}>
+      {steps.map((step) => (
+        <li key={step}>
+          <BrandedText>{step}</BrandedText>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ frontend/.vite/
 
 # OS
 .DS_Store
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+frontend/.ds-css/

--- a/frontend/scripts/build-ds-css.mjs
+++ b/frontend/scripts/build-ds-css.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/* ============================================================================
+   Build the design-system stylesheet entry for the claude.ai/design sync.
+
+     node scripts/build-ds-css.mjs
+
+   The app loads theme.css (tokens) and styles.css (everything else) as two
+   separate imports from main.jsx. The design-sync converter takes ONE stylesheet
+   path and copies it verbatim, so relative @imports inside it would not resolve
+   from the output directory — the two files have to be concatenated instead.
+
+   Order matters twice over: theme.css must come first because styles.css reads
+   its custom properties, and theme.css's webfont @import must stay the very
+   first statement in the file or CSS drops it.
+
+   Root-relative asset urls are inlined as data URIs. In the app those resolve
+   against public/, but the stylesheet is consumed from a design project where
+   there is no such origin — the brand asterisk mask would silently render as
+   nothing, in every design built with the system. Inlining keeps it visible.
+
+   Output is generated and gitignored. `buildCmd` in .design-sync/config.json
+   runs this before every sync.
+   ============================================================================ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SOURCES = ["src/theme.css", "src/styles.css"];
+const OUT = join(ROOT, ".ds-css/design-system.css");
+const MIME = { svg: "image/svg+xml", png: "image/png", jpg: "image/jpeg", webp: "image/webp" };
+
+let inlined = 0;
+
+// url("/foo.svg") -> url("data:image/svg+xml;base64,…"), for files that exist
+// under public/. Anything that doesn't resolve is left alone rather than
+// rewritten to a broken data URI — a visible 404 beats a silent one.
+function inlineAssets(css) {
+  return css.replace(/url\(\s*(['"]?)(\/[^'")\s]+)\1\s*\)/g, (whole, _q, path) => {
+    const file = join(ROOT, "public", path);
+    const mime = MIME[path.split(".").pop().toLowerCase()];
+    if (!mime || !existsSync(file)) return whole;
+    inlined += 1;
+    return `url("data:${mime};base64,${readFileSync(file).toString("base64")}")`;
+  });
+}
+
+const parts = SOURCES.map((rel) => {
+  const body = inlineAssets(readFileSync(join(ROOT, rel), "utf8"));
+  return `/* ─── ${rel} ─── */\n${body.trim()}\n`;
+});
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, parts.join("\n"));
+
+const kb = (Buffer.byteLength(parts.join("\n")) / 1024).toFixed(0);
+console.log(
+  `design-system.css  ${SOURCES.join(" + ")}  ->  .ds-css/  (${kb} KB, ${inlined} asset(s) inlined)`,
+);

--- a/frontend/src/design-system.js
+++ b/frontend/src/design-system.js
@@ -1,0 +1,14 @@
+/* ============================================================================
+   The design system's public surface.
+
+   This is what gets bundled for claude.ai/design — the parts of the UI that are
+   genuinely reusable, as opposed to the page components in ./components, which
+   are application screens bound to the API and to auth.
+
+   Most of this design system is CSS, not React: the tokens in theme.css and the
+   class vocabulary in styles.css. See .design-sync/conventions.md for how to
+   build with it. Only components that carry brand meaning a class can't express
+   belong here.
+   ============================================================================ */
+
+export { default as BrandName, BrandedText } from "./components/BrandName.jsx";


### PR DESCRIPTION
Sets up `/design-sync` for this repo and uploads the design system to a Claude Design project, so the design agent builds with our real tokens, CSS, and brand mark instead of generic components.

## Scope

The app has **no component library** — all 17 React exports under `frontend/src/components/` are API-bound page screens (auth, dashboard, marketing, demo). There's no `dist/`, no lib build target, no Storybook. What's genuinely reusable is the CSS: 51 tokens in `theme.css`, the class vocabulary in `styles.css`, and `BrandName`/`BrandedText`.

`frontend/src/design-system.js` is the new public surface — adding a component to the design system means exporting it there.

## Two problems the sync surfaced

**`cssEntry` is copied verbatim**, so relative `@import`s inside it don't resolve from the output dir. `theme.css` and `styles.css` have to be concatenated. `frontend/scripts/build-ds-css.mjs` does that, ordered so theme comes first (styles reads its custom properties) and the webfont `@import` stays the very first statement.

**The brand asterisk would have rendered invisible.** `.brand-name-mark` masks `url("/brand/five-star-asterisk.svg")` — resolves against `public/` in the app, against nothing in a design project. No error, no warning, just a missing mark in every design ever built with the system. The generator now inlines root-relative `public/` assets as base64 data URIs.

## Verification

- `package-validate.mjs` exits 0 — bundle complete, render check 2/2 clean
- Both components have authored preview cards (4 cells each), all graded `good` against real screenshots
- `[FONT_REMOTE]` for Manrope/Newsreader is expected and documented — `theme.css` loads them from Google Fonts at runtime

## Files

- `.design-sync/config.json` — sync config incl. the project pin
- `.design-sync/conventions.md` — prepended to the uploaded README; tells the design agent the type pairing, colour logic, and crucially which class families are primitives vs. app screens it shouldn't build from
- `.design-sync/previews/*.tsx` — the preview compositions, drawn from real `MarketingPage.jsx` usage
- `.design-sync/NOTES.md` — gotchas and re-sync risks

🤖 Generated with [Claude Code](https://claude.com/claude-code)