### PR TITLE
Build organization platform and social publishing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,5 +4,28 @@ JWT_SECRET_KEY=change-this-in-real-env
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 FRONTEND_ORIGIN=http://localhost:5173
+APP_BASE_URL=http://localhost:5173
+API_BASE_URL=http://localhost:8000
 RATE_LIMIT_ENABLED=true
 SENTRY_DSN=
+
+# Encrypts stored social access tokens. Use a long, random production secret.
+# When blank, JWT_SECRET_KEY is used as the local-development fallback.
+OAUTH_TOKEN_ENCRYPTION_KEY=
+
+# Meta/Facebook Login powers Facebook Page connections.
+META_CLIENT_ID=1772047737482068
+META_CLIENT_SECRET=
+
+# Instagram Login uses the Instagram app credentials shown in the
+# Instagram API setup for the Meta app.
+INSTAGRAM_CLIENT_ID=1024263007127319
+INSTAGRAM_CLIENT_SECRET=
+
+TIKTOK_CLIENT_KEY=
+TIKTOK_CLIENT_SECRET=
+
+
+# The in-process scheduler publishes due social posts on a single app machine.
+SOCIAL_SCHEDULER_ENABLED=true
+SOCIAL_SCHEDULER_INTERVAL_SECONDS=30

--- a/backend/app/ai.py
+++ b/backend/app/ai.py
@@ -3,7 +3,7 @@ import json
 from openai import OpenAI
 from pydantic import ValidationError
 
-from .schemas import DigestContent
+from .schemas import DigestContent, SocialDraftContent
 
 STYLE_PROMPTS = {
     "shorten": "Shorten this into a concise public review (2-3 sentences max). Keep the core message.",
@@ -37,6 +37,29 @@ def polish_review(api_key: str, content: str, style: str) -> str:
     )
 
     return response.choices[0].message.content.strip()
+
+
+def generate_social_drafts(api_key: str, content: str) -> SocialDraftContent:
+    """Adapt one source caption into editable drafts for each available channel."""
+    client = OpenAI(api_key=api_key)
+    response = client.responses.parse(
+        model="gpt-4o-mini",
+        instructions=(
+            "You are a careful social media editor for local businesses. "
+            "Rewrite the supplied source caption for Facebook, Instagram, and TikTok. "
+            "Preserve every factual claim, date, offer, name, and "
+            "constraint from the source. Do not invent details. Keep the business's "
+            "voice natural and make each version ready for a human to review. "
+            "Instagram may use a small number of relevant hashtags. TikTok should "
+            "start with a concise hook. Facebook should feel conversational."
+        ),
+        input=content,
+        max_output_tokens=1800,
+        text_format=SocialDraftContent,
+    )
+    if not response.output_parsed:
+        raise ValueError("OpenAI did not return platform drafts")
+    return response.output_parsed
 
 
 def generate_digest_content(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,8 +19,18 @@ class Settings(BaseSettings):
     sendgrid_api_key: str = ""
     sender_email: str = "noreply@fivestar.fyi"
     app_base_url: str = "http://localhost:5173"
+    api_base_url: str = "http://localhost:8000"
     rate_limit_enabled: bool = True
     sentry_dsn: str = ""
+    oauth_token_encryption_key: str = ""
+    meta_client_id: str = ""
+    meta_client_secret: str = ""
+    instagram_client_id: str = ""
+    instagram_client_secret: str = ""
+    tiktok_client_key: str = ""
+    tiktok_client_secret: str = ""
+    social_scheduler_enabled: bool = True
+    social_scheduler_interval_seconds: int = 30
 
     model_config = SettingsConfigDict(env_file=str(_ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from .database import get_db
-from .models import OrganizationMember, Role, User
+from .models import Location, LocationMembership, LocationRole, OrganizationMember, Role, User
 from .security import decode_token
 
 security = HTTPBearer(auto_error=False)
@@ -48,3 +48,100 @@ def require_org_admin(db: Session, user: User, org_id: int) -> OrganizationMembe
     if membership.role != Role.ADMIN:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
     return membership
+
+
+def get_accessible_locations(
+    db: Session,
+    user: User,
+    org_id: int,
+) -> tuple[OrganizationMember, list[Location]]:
+    membership = get_user_org_membership(db, user, org_id)
+    query = select(Location).where(Location.organization_id == org_id).order_by(Location.is_default.desc(), Location.name)
+    if membership.role == Role.LOCATION:
+        query = (
+            query.join(LocationMembership, LocationMembership.location_id == Location.id)
+            .where(LocationMembership.user_id == user.id)
+        )
+    return membership, list(db.scalars(query).all())
+
+
+def require_location_access(
+    db: Session,
+    user: User,
+    org_id: int,
+    location_id: int,
+    *,
+    manage: bool = False,
+) -> tuple[OrganizationMember, Location, LocationRole | None]:
+    membership = get_user_org_membership(db, user, org_id)
+    location = db.scalar(
+        select(Location).where(
+            Location.id == location_id,
+            Location.organization_id == org_id,
+        )
+    )
+    if not location:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Location not found or access denied")
+
+    if membership.role == Role.ADMIN:
+        return membership, location, None
+
+    if membership.role == Role.VIEWER:
+        if manage:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Location admin role required")
+        return membership, location, None
+
+    location_membership = db.scalar(
+        select(LocationMembership).where(
+            LocationMembership.user_id == user.id,
+            LocationMembership.organization_id == org_id,
+            LocationMembership.location_id == location_id,
+        )
+    )
+    if not location_membership:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Location not found or access denied")
+    if manage and location_membership.role != LocationRole.MANAGER:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Location manager role required")
+    return membership, location, location_membership.role
+
+
+def resolve_location_scope(
+    db: Session,
+    user: User,
+    org_id: int,
+    location_id: int | None,
+    *,
+    manage: bool = False,
+    require_single: bool = False,
+) -> tuple[OrganizationMember, list[Location]]:
+    if location_id is not None:
+        membership, location, _ = require_location_access(
+            db,
+            user,
+            org_id,
+            location_id,
+            manage=manage,
+        )
+        return membership, [location]
+
+    membership, locations = get_accessible_locations(db, user, org_id)
+    if not locations:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No accessible locations")
+    if manage and membership.role == Role.VIEWER:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Location admin role required")
+    if manage and membership.role == Role.LOCATION:
+        manager_ids = set(
+            db.scalars(
+                select(LocationMembership.location_id).where(
+                    LocationMembership.user_id == user.id,
+                    LocationMembership.organization_id == org_id,
+                    LocationMembership.role == LocationRole.MANAGER,
+                )
+            ).all()
+        )
+        locations = [location for location in locations if location.id in manager_ids]
+        if not locations:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Location manager role required")
+    if require_single and len(locations) != 1:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Choose a location")
+    return membership, locations

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,23 +1,56 @@
+import asyncio
 import json
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
+from urllib.parse import urlencode
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
+import httpx
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from pydantic import ValidationError
 from slowapi.errors import RateLimitExceeded
 from slowapi import _rate_limit_exceeded_handler
-from sqlalchemy import func, select
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.orm import Session, joinedload
 
-from .ai import generate_digest_content, polish_review
+from .ai import generate_digest_content, generate_social_drafts, polish_review
 from .config import get_settings
-from .database import Base, engine, get_db
-from .dependencies import get_current_user, get_user_org_membership, require_org_admin
-from .models import Digest, DigestStatus, Feedback, Invite, Organization, OrganizationMember, PasswordResetToken, Role, User
+from .database import Base, SessionLocal, engine, get_db
+from .dependencies import (
+    get_accessible_locations,
+    get_current_user,
+    get_user_org_membership,
+    require_location_access,
+    require_org_admin,
+    resolve_location_scope,
+)
+from .models import (
+    Digest,
+    DigestStatus,
+    Feedback,
+    Initiative,
+    InitiativeStatus,
+    InitiativeVote,
+    Invite,
+    Location,
+    LocationMembership,
+    LocationRole,
+    Organization,
+    OrganizationMember,
+    PasswordResetToken,
+    Role,
+    SocialConnection,
+    SocialConnectionSetup,
+    SocialOAuthState,
+    SocialPost,
+    SocialPostTarget,
+    User,
+)
 from .schemas import (
     AuthResponse,
+    BoardOut,
     DigestContent,
     DigestGenerate,
     DigestOut,
@@ -32,16 +65,38 @@ from .schemas import (
     InviteCreate,
     InviteInfo,
     InviteOut,
+    InitiativeCreate,
+    InitiativeOut,
+    InitiativeUpdate,
+    InitiativeVoteUpdate,
+    LocationAssignment,
+    LocationCreate,
+    LocationOut,
+    LocationReviewLinksUpdate,
+    LocationUpdate,
     MemberOut,
+    MemberLocationAssignmentsUpdate,
     MemberUpdateRole,
+    MetaConnectionComplete,
+    MetaConnectionOptionsOut,
+    MetaInstagramAccountOut,
+    MetaPageOptionOut,
     OrganizationCreate,
     OrganizationOut,
     OrganizationReviewLinksUpdate,
     OrganizationSearchResult,
     OrganizationUpdate,
+    PublicInitiativeOut,
     ReviewLink,
     ReviewPolishRequest,
     ReviewPolishResponse,
+    SocialAuthorizationOut,
+    SocialConnectionOut,
+    SocialDraftContent,
+    SocialDraftGenerate,
+    SocialPostCreate,
+    SocialPostOut,
+    SocialPostTargetOut,
     ForgotPasswordRequest,
     ResetPasswordRequest,
     Token,
@@ -60,6 +115,25 @@ from .security import (
     hash_reset_token,
     is_invite_valid,
     verify_password,
+)
+from .social import (
+    PROVIDER_DETAILS,
+    SUPPORTED_PROVIDERS,
+    SocialProviderError,
+    build_authorization_url,
+    decrypt_token,
+    encrypt_token,
+    exchange_social_code,
+    fetch_facebook_pages,
+    fetch_social_identity,
+    generate_oauth_state,
+    hash_oauth_state,
+    provider_configured,
+    publish_social_content,
+    requested_scopes,
+    revoke_social_token,
+    token_expiry,
+    validate_provider,
 )
 
 settings = get_settings()
@@ -83,6 +157,20 @@ RESERVED_PATH_PREFIXES = (
     "openapi.json",
 )
 
+
+def _location_timezone(location: Location) -> ZoneInfo:
+    try:
+        return ZoneInfo(location.timezone)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("UTC")
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 app = FastAPI(title=settings.app_name)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
@@ -101,8 +189,23 @@ app.add_middleware(
 
 
 @app.on_event("startup")
-def on_startup() -> None:
-    pass  # Schema is managed by Alembic migrations (run before app starts)
+async def on_startup() -> None:
+    # Schema is managed by Alembic migrations (run before app starts).
+    if settings.social_scheduler_enabled:
+        app.state.social_scheduler_task = asyncio.create_task(
+            _social_scheduler_loop()
+        )
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    task = getattr(app.state, "social_scheduler_task", None)
+    if task:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +308,45 @@ def reset_password(request: Request, payload: ResetPasswordRequest, db: Session 
 # ---------------------------------------------------------------------------
 
 
+def _access_role_from_membership(
+    membership: OrganizationMember,
+    location_roles: list[LocationRole] | None = None,
+) -> str:
+    """Return the unambiguous access level shown in the product UI."""
+    if membership.role == Role.ADMIN:
+        return "organization_admin"
+    if membership.role == Role.VIEWER:
+        return "organization_viewer"
+    if LocationRole.MANAGER in (location_roles or []):
+        return "location_admin"
+    return "location_viewer"
+
+
+def _organization_out(db: Session, membership: OrganizationMember) -> OrganizationOut:
+    org = membership.organization
+    location_roles: list[LocationRole] = []
+    if membership.role == Role.LOCATION:
+        location_roles = list(
+            db.scalars(
+                select(LocationMembership.role).where(
+                    LocationMembership.user_id == membership.user_id,
+                    LocationMembership.organization_id == membership.organization_id,
+                )
+            ).all()
+        )
+    return OrganizationOut(
+        id=org.id,
+        name=org.name,
+        created_at=org.created_at,
+        created_by=org.created_by,
+        role=_access_role_from_membership(membership, location_roles),
+        feedback_token=org.feedback_token,
+        review_links=org.review_links,
+        can_view_all_locations=membership.role in {Role.ADMIN, Role.VIEWER},
+        can_manage_organization=membership.role == Role.ADMIN,
+    )
+
+
 @app.post("/organizations", response_model=OrganizationOut, status_code=status.HTTP_201_CREATED)
 def create_organization(
     payload: OrganizationCreate,
@@ -216,19 +358,19 @@ def create_organization(
     db.flush()
 
     membership = OrganizationMember(user_id=user.id, organization_id=org.id, role=Role.ADMIN)
-    db.add(membership)
+    default_location = Location(
+        organization_id=org.id,
+        name=org.name,
+        is_default=True,
+        feedback_token=org.feedback_token,
+        review_links=org.review_links,
+        created_by=user.id,
+    )
+    db.add_all([membership, default_location])
     db.commit()
     db.refresh(org)
 
-    return OrganizationOut(
-        id=org.id,
-        name=org.name,
-        created_at=org.created_at,
-        created_by=org.created_by,
-        role=Role.ADMIN.value,
-        feedback_token=org.feedback_token,
-review_links=org.review_links,
-    )
+    return _organization_out(db, membership)
 
 
 @app.get("/organizations", response_model=list[OrganizationOut])
@@ -247,18 +389,7 @@ def list_organizations(
         .all()
     )
 
-    return [
-        OrganizationOut(
-            id=m.organization.id,
-            name=m.organization.name,
-            created_at=m.organization.created_at,
-            created_by=m.organization.created_by,
-            role=m.role.value,
-            feedback_token=m.organization.feedback_token,
-review_links=m.organization.review_links,
-        )
-        for m in memberships
-    ]
+    return [_organization_out(db, membership) for membership in memberships]
 
 
 @app.get("/organizations/search", response_model=list[OrganizationSearchResult])
@@ -287,16 +418,7 @@ def get_organization(
     db: Session = Depends(get_db),
 ) -> OrganizationOut:
     membership = get_user_org_membership(db, user, org_id)
-    org = membership.organization
-    return OrganizationOut(
-        id=org.id,
-        name=org.name,
-        created_at=org.created_at,
-        created_by=org.created_by,
-        role=membership.role.value,
-        feedback_token=org.feedback_token,
-review_links=org.review_links,
-    )
+    return _organization_out(db, membership)
 
 
 @app.patch("/organizations/{org_id}", response_model=OrganizationOut)
@@ -313,15 +435,7 @@ def update_organization(
     db.commit()
     db.refresh(org)
 
-    return OrganizationOut(
-        id=org.id,
-        name=org.name,
-        created_at=org.created_at,
-        created_by=org.created_by,
-        role=membership.role.value,
-        feedback_token=org.feedback_token,
-review_links=org.review_links,
-    )
+    return _organization_out(db, membership)
 
 
 @app.patch("/organizations/{org_id}/review-links", response_model=OrganizationOut)
@@ -334,18 +448,18 @@ def update_review_links(
     membership = require_org_admin(db, user, org_id)
     org = membership.organization
     org.review_links = [link.model_dump() for link in payload.review_links]
+    default_location = db.scalar(
+        select(Location).where(
+            Location.organization_id == org_id,
+            Location.is_default.is_(True),
+        )
+    )
+    if default_location:
+        default_location.review_links = org.review_links
     db.commit()
     db.refresh(org)
 
-    return OrganizationOut(
-        id=org.id,
-        name=org.name,
-        created_at=org.created_at,
-        created_by=org.created_by,
-        role=membership.role.value,
-        feedback_token=org.feedback_token,
-        review_links=org.review_links,
-    )
+    return _organization_out(db, membership)
 
 
 @app.delete("/organizations/{org_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -360,6 +474,1017 @@ def delete_organization(
 
 
 # ---------------------------------------------------------------------------
+# Organization social connections
+# ---------------------------------------------------------------------------
+
+
+def _validated_social_provider(provider: str) -> str:
+    try:
+        return validate_provider(provider)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Social provider not found",
+        ) from exc
+
+
+def _social_connection_out(
+    provider: str,
+    connection: SocialConnection | None,
+) -> SocialConnectionOut:
+    details = PROVIDER_DETAILS[provider]
+    connection_status = connection.status if connection else "not_connected"
+    provider_data = connection.provider_data or {} if connection else {}
+    diagnostic = None
+    if connection and connection.expires_at and connection.expires_at <= datetime.utcnow():
+        connection_status = "reconnect_required"
+        diagnostic = "The saved authorization expired. Reconnect this destination."
+    if (
+        provider == "facebook"
+        and connection
+        and provider_data.get("auth_type") != "facebook_login"
+    ):
+        connection_status = "reconnect_required"
+        diagnostic = (
+            "Reconnect Facebook to choose the Page this organization should publish to."
+        )
+    if provider == "instagram" and not connection:
+        diagnostic = (
+            "Connect directly, or connect Meta and choose a Facebook Page that has "
+            "a professional Instagram account linked."
+        )
+    return SocialConnectionOut(
+        provider=provider,
+        name=details["name"],
+        description=details["description"],
+        configured=provider_configured(provider, settings),
+        connected=connection is not None,
+        publishing_enabled=bool(details["publishing_enabled"]),
+        status=connection_status,
+        provider_account_id=connection.provider_account_id if connection else None,
+        provider_account_name=connection.provider_account_name if connection else None,
+        scopes=connection.scopes or [] if connection else [],
+        expires_at=connection.expires_at if connection else None,
+        connected_at=connection.created_at if connection else None,
+        connection_method=provider_data.get("auth_type"),
+        linked_page_name=provider_data.get("facebook_page_name"),
+        diagnostic=diagnostic,
+    )
+
+
+def _upsert_social_connection(
+    db: Session,
+    *,
+    organization_id: int,
+    provider: str,
+    connected_by: int,
+    access_token: str,
+    provider_account_id: str,
+    provider_account_name: str,
+    provider_data: dict | None,
+    scopes: list[str],
+    expires_at: datetime | None = None,
+    refresh_token: str | None = None,
+) -> SocialConnection:
+    connection = db.scalar(
+        select(SocialConnection).where(
+            SocialConnection.organization_id == organization_id,
+            SocialConnection.provider == provider,
+        )
+    )
+    if not connection:
+        connection = SocialConnection(
+            organization_id=organization_id,
+            provider=provider,
+            access_token_encrypted=encrypt_token(access_token, settings),
+            connected_by=connected_by,
+        )
+        db.add(connection)
+    else:
+        connection.access_token_encrypted = encrypt_token(access_token, settings)
+        connection.connected_by = connected_by
+
+    connection.refresh_token_encrypted = (
+        encrypt_token(refresh_token, settings) if refresh_token else None
+    )
+    connection.status = "connected"
+    connection.provider_account_id = provider_account_id or None
+    connection.provider_account_name = provider_account_name or None
+    connection.provider_data = provider_data or {}
+    connection.scopes = scopes
+    connection.expires_at = expires_at
+    connection.updated_at = datetime.utcnow()
+    return connection
+
+
+@app.get(
+    "/organizations/{org_id}/social-connections",
+    response_model=list[SocialConnectionOut],
+)
+def list_social_connections(
+    org_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[SocialConnectionOut]:
+    require_org_admin(db, user, org_id)
+    connections = {
+        connection.provider: connection
+        for connection in db.scalars(
+            select(SocialConnection).where(SocialConnection.organization_id == org_id)
+        ).all()
+    }
+    return [
+        _social_connection_out(provider, connections.get(provider))
+        for provider in SUPPORTED_PROVIDERS
+    ]
+
+
+@app.post(
+    "/organizations/{org_id}/social-connections/{provider}/authorize",
+    response_model=SocialAuthorizationOut,
+)
+def authorize_social_connection(
+    org_id: int,
+    provider: str,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SocialAuthorizationOut:
+    provider = _validated_social_provider(provider)
+    require_org_admin(db, user, org_id)
+    if not provider_configured(provider, settings):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"{PROVIDER_DETAILS[provider]['name']} app credentials are not configured",
+        )
+
+    raw_state = generate_oauth_state()
+    now = datetime.utcnow()
+    db.add(
+        SocialOAuthState(
+            state_hash=hash_oauth_state(raw_state),
+            organization_id=org_id,
+            provider=provider,
+            user_id=user.id,
+            created_at=now,
+            expires_at=now + timedelta(minutes=10),
+        )
+    )
+    db.commit()
+    return SocialAuthorizationOut(
+        authorization_url=build_authorization_url(provider, raw_state, settings)
+    )
+
+
+def _social_callback_redirect(
+    org_id: int,
+    provider: str,
+    result: str,
+    message: str | None = None,
+    **extra: str,
+) -> RedirectResponse:
+    query = {"social": result, "provider": provider}
+    if message:
+        query["message"] = message
+    query.update(extra)
+    destination = (
+        f"{settings.frontend_origin.rstrip('/')}/org/{org_id}/social?{urlencode(query)}"
+    )
+    return RedirectResponse(destination, status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.get("/oauth/social/{provider}/callback")
+def social_oauth_callback(
+    provider: str,
+    state_value: str | None = Query(default=None, alias="state"),
+    code: str | None = None,
+    error: str | None = None,
+    error_description: str | None = None,
+    db: Session = Depends(get_db),
+) -> RedirectResponse:
+    provider = _validated_social_provider(provider)
+    if not state_value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing OAuth state",
+        )
+
+    oauth_state = db.scalar(
+        select(SocialOAuthState).where(
+            SocialOAuthState.state_hash == hash_oauth_state(state_value),
+            SocialOAuthState.provider == provider,
+        )
+    )
+    now = datetime.utcnow()
+    if not oauth_state or oauth_state.used_at or oauth_state.expires_at <= now:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired OAuth state",
+        )
+
+    oauth_state.used_at = now
+    db.commit()
+    if error or not code:
+        return _social_callback_redirect(
+            oauth_state.organization_id,
+            provider,
+            "error",
+            error_description or error or "Authorization was cancelled",
+        )
+
+    try:
+        token_data = exchange_social_code(provider, code, settings)
+        access_token = token_data.get("access_token")
+        if not access_token:
+            raise SocialProviderError("The provider did not return an access token")
+        if provider == "facebook":
+            setup_token = generate_oauth_state()
+            db.add(
+                SocialConnectionSetup(
+                    token_hash=hash_oauth_state(setup_token),
+                    organization_id=oauth_state.organization_id,
+                    provider=provider,
+                    user_id=oauth_state.user_id,
+                    access_token_encrypted=encrypt_token(access_token, settings),
+                    scopes=requested_scopes(provider, token_data),
+                    created_at=now,
+                    expires_at=now + timedelta(minutes=15),
+                )
+            )
+            db.commit()
+            return _social_callback_redirect(
+                oauth_state.organization_id,
+                provider,
+                "selection_required",
+                setup=setup_token,
+            )
+        identity = fetch_social_identity(provider, token_data)
+    except (SocialProviderError, httpx.HTTPError) as exc:
+        return _social_callback_redirect(
+            oauth_state.organization_id,
+            provider,
+            "error",
+            str(exc),
+        )
+
+    refresh_token = token_data.get("refresh_token")
+    identity_data = identity.get("data") or {}
+    if provider == "instagram":
+        identity_data.setdefault("auth_type", "instagram_login")
+    _upsert_social_connection(
+        db,
+        organization_id=oauth_state.organization_id,
+        provider=provider,
+        connected_by=oauth_state.user_id,
+        access_token=access_token,
+        provider_account_id=identity.get("id") or "",
+        provider_account_name=identity.get("name") or "",
+        provider_data=identity_data,
+        scopes=requested_scopes(provider, token_data),
+        expires_at=token_expiry(token_data),
+        refresh_token=refresh_token,
+    )
+    db.commit()
+
+    return _social_callback_redirect(
+        oauth_state.organization_id,
+        provider,
+        "connected",
+    )
+
+
+def _get_social_connection_setup(
+    db: Session,
+    *,
+    organization_id: int,
+    user_id: int,
+    provider: str,
+    setup_token: str,
+) -> SocialConnectionSetup:
+    setup = db.scalar(
+        select(SocialConnectionSetup).where(
+            SocialConnectionSetup.token_hash == hash_oauth_state(setup_token),
+            SocialConnectionSetup.organization_id == organization_id,
+            SocialConnectionSetup.user_id == user_id,
+            SocialConnectionSetup.provider == provider,
+        )
+    )
+    now = datetime.utcnow()
+    if not setup or setup.used_at or setup.expires_at <= now:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This connection setup expired. Start the connection again.",
+        )
+    return setup
+
+
+@app.get(
+    "/organizations/{org_id}/social-connections/facebook/options",
+    response_model=MetaConnectionOptionsOut,
+)
+def list_facebook_page_options(
+    org_id: int,
+    setup: str,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> MetaConnectionOptionsOut:
+    require_org_admin(db, user, org_id)
+    connection_setup = _get_social_connection_setup(
+        db,
+        organization_id=org_id,
+        user_id=user.id,
+        provider="facebook",
+        setup_token=setup,
+    )
+    try:
+        pages = fetch_facebook_pages(
+            decrypt_token(connection_setup.access_token_encrypted, settings)
+        )
+    except (SocialProviderError, httpx.HTTPError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+
+    return MetaConnectionOptionsOut(
+        pages=[
+            MetaPageOptionOut(
+                id=page["id"],
+                name=page["name"],
+                tasks=page.get("tasks") or [],
+                instagram=(
+                    MetaInstagramAccountOut(**page["instagram"])
+                    if page.get("instagram")
+                    else None
+                ),
+            )
+            for page in pages
+        ]
+    )
+
+
+@app.post(
+    "/organizations/{org_id}/social-connections/facebook/complete",
+    response_model=list[SocialConnectionOut],
+)
+def complete_facebook_page_connection(
+    org_id: int,
+    payload: MetaConnectionComplete,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[SocialConnectionOut]:
+    require_org_admin(db, user, org_id)
+    connection_setup = _get_social_connection_setup(
+        db,
+        organization_id=org_id,
+        user_id=user.id,
+        provider="facebook",
+        setup_token=payload.setup_token,
+    )
+    user_access_token = decrypt_token(
+        connection_setup.access_token_encrypted,
+        settings,
+    )
+    try:
+        pages = fetch_facebook_pages(user_access_token)
+    except (SocialProviderError, httpx.HTTPError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+
+    selected_page = next(
+        (page for page in pages if page["id"] == payload.page_id),
+        None,
+    )
+    if not selected_page:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The selected Facebook Page is no longer available to this account.",
+        )
+
+    granted_scopes = connection_setup.scopes or list(
+        PROVIDER_DETAILS["facebook"]["scopes"]
+    )
+    page_data = {
+        "auth_type": "facebook_login",
+        "page_id": selected_page["id"],
+        "tasks": selected_page.get("tasks") or [],
+        "instagram": selected_page.get("instagram"),
+    }
+    _upsert_social_connection(
+        db,
+        organization_id=org_id,
+        provider="facebook",
+        connected_by=user.id,
+        access_token=selected_page["access_token"],
+        refresh_token=user_access_token,
+        provider_account_id=selected_page["id"],
+        provider_account_name=selected_page["name"],
+        provider_data=page_data,
+        scopes=granted_scopes,
+    )
+
+    instagram = selected_page.get("instagram")
+    linked_instagram_connection = db.scalar(
+        select(SocialConnection).where(
+            SocialConnection.organization_id == org_id,
+            SocialConnection.provider == "instagram",
+        )
+    )
+    if instagram:
+        _upsert_social_connection(
+            db,
+            organization_id=org_id,
+            provider="instagram",
+            connected_by=user.id,
+            access_token=selected_page["access_token"],
+            provider_account_id=instagram["id"],
+            provider_account_name=(
+                instagram.get("username")
+                or instagram.get("name")
+                or "Instagram account"
+            ),
+            provider_data={
+                "auth_type": "facebook_login",
+                "facebook_page_id": selected_page["id"],
+                "facebook_page_name": selected_page["name"],
+                "username": instagram.get("username"),
+                "profile_picture_url": instagram.get("profile_picture_url"),
+            },
+            scopes=granted_scopes,
+        )
+    elif (
+        linked_instagram_connection
+        and (linked_instagram_connection.provider_data or {}).get("auth_type")
+        == "facebook_login"
+    ):
+        db.delete(linked_instagram_connection)
+
+    connection_setup.used_at = datetime.utcnow()
+    db.commit()
+
+    connections = {
+        connection.provider: connection
+        for connection in db.scalars(
+            select(SocialConnection).where(
+                SocialConnection.organization_id == org_id
+            )
+        ).all()
+    }
+    return [
+        _social_connection_out(provider, connections.get(provider))
+        for provider in SUPPORTED_PROVIDERS
+    ]
+
+
+@app.delete(
+    "/organizations/{org_id}/social-connections/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def disconnect_social_connection(
+    org_id: int,
+    provider: str,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    provider = _validated_social_provider(provider)
+    require_org_admin(db, user, org_id)
+    connection = db.scalar(
+        select(SocialConnection).where(
+            SocialConnection.organization_id == org_id,
+            SocialConnection.provider == provider,
+        )
+    )
+    if not connection:
+        return
+    token_to_revoke = (
+        connection.refresh_token_encrypted
+        if provider == "facebook" and connection.refresh_token_encrypted
+        else connection.access_token_encrypted
+    )
+    revoke_social_token(provider, token_to_revoke, settings)
+    if provider == "facebook":
+        linked_instagram = db.scalar(
+            select(SocialConnection).where(
+                SocialConnection.organization_id == org_id,
+                SocialConnection.provider == "instagram",
+            )
+        )
+        if (
+            linked_instagram
+            and (linked_instagram.provider_data or {}).get("auth_type")
+            == "facebook_login"
+        ):
+            db.delete(linked_instagram)
+    db.delete(connection)
+    db.commit()
+
+
+def _social_post_out(post: SocialPost) -> SocialPostOut:
+    return SocialPostOut(
+        id=post.id,
+        organization_id=post.organization_id,
+        master_caption=post.master_caption,
+        media_urls=post.media_urls or [],
+        status=post.status,
+        scheduled_at=post.scheduled_at,
+        published_at=post.published_at,
+        created_by=post.created_by,
+        created_at=post.created_at,
+        updated_at=post.updated_at,
+        targets=[
+            SocialPostTargetOut(
+                id=target.id,
+                provider=target.provider,
+                content=target.content,
+                status=target.status,
+                remote_post_id=target.remote_post_id,
+                error=target.error,
+                published_at=target.published_at,
+            )
+            for target in post.targets
+        ],
+    )
+
+
+def _load_social_post(
+    db: Session,
+    *,
+    organization_id: int,
+    post_id: int,
+) -> SocialPost:
+    post = (
+        db.execute(
+            select(SocialPost)
+            .options(joinedload(SocialPost.targets))
+            .where(
+                SocialPost.id == post_id,
+                SocialPost.organization_id == organization_id,
+            )
+        )
+        .unique()
+        .scalar_one_or_none()
+    )
+    if not post:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Social post not found",
+        )
+    return post
+
+
+@app.post(
+    "/organizations/{org_id}/social-posts/drafts/generate",
+    response_model=SocialDraftContent,
+)
+def generate_social_post_drafts(
+    org_id: int,
+    payload: SocialDraftGenerate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SocialDraftContent:
+    require_org_admin(db, user, org_id)
+    if not settings.openai_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="AI generation is not configured",
+        )
+    try:
+        return generate_social_drafts(
+            api_key=settings.openai_api_key,
+            content=payload.master_caption,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"AI generation failed: {exc}",
+        ) from exc
+
+
+def _publish_social_post(db: Session, post: SocialPost) -> SocialPost:
+    if post.status == "published":
+        return post
+
+    connections = {
+        connection.provider: connection
+        for connection in db.scalars(
+            select(SocialConnection).where(
+                SocialConnection.organization_id == post.organization_id
+            )
+        ).all()
+    }
+    post.status = "publishing"
+    db.commit()
+
+    for target in post.targets:
+        if target.status == "published":
+            continue
+        target.status = "publishing"
+        target.error = None
+        db.commit()
+
+        connection = connections.get(target.provider)
+        try:
+            if not connection:
+                raise SocialProviderError(
+                    f"{PROVIDER_DETAILS[target.provider]['name']} is not connected"
+                )
+            if connection.expires_at and connection.expires_at <= datetime.utcnow():
+                raise SocialProviderError(
+                    f"{PROVIDER_DETAILS[target.provider]['name']} must be reconnected"
+                )
+            if not connection.provider_account_id:
+                raise SocialProviderError(
+                    f"{PROVIDER_DETAILS[target.provider]['name']} has no publishing account selected"
+                )
+            if (
+                target.provider == "facebook"
+                and (connection.provider_data or {}).get("auth_type")
+                != "facebook_login"
+            ):
+                raise SocialProviderError(
+                    "Reconnect Facebook and choose a Page before publishing"
+                )
+
+            remote_id = publish_social_content(
+                target.provider,
+                account_id=connection.provider_account_id,
+                access_token=decrypt_token(
+                    connection.access_token_encrypted,
+                    settings,
+                ),
+                content=target.content,
+                media_urls=post.media_urls or [],
+                provider_data=connection.provider_data or {},
+            )
+        except (SocialProviderError, httpx.HTTPError) as exc:
+            target.status = "failed"
+            target.error = str(exc)
+            target.remote_post_id = None
+            target.published_at = None
+        else:
+            target.status = "published"
+            target.error = None
+            target.remote_post_id = remote_id
+            target.published_at = datetime.utcnow()
+        db.commit()
+
+    target_statuses = {target.status for target in post.targets}
+    now = datetime.utcnow()
+    if target_statuses == {"published"}:
+        post.status = "published"
+        post.published_at = now
+    elif "published" in target_statuses:
+        post.status = "partial_failure"
+        post.published_at = now
+    else:
+        post.status = "failed"
+        post.published_at = None
+    db.commit()
+    db.refresh(post)
+    return post
+
+
+@app.get(
+    "/organizations/{org_id}/social-posts",
+    response_model=list[SocialPostOut],
+)
+def list_social_posts(
+    org_id: int,
+    limit: int = Query(default=25, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[SocialPostOut]:
+    require_org_admin(db, user, org_id)
+    posts = (
+        db.execute(
+            select(SocialPost)
+            .options(joinedload(SocialPost.targets))
+            .where(SocialPost.organization_id == org_id)
+            .order_by(SocialPost.created_at.desc())
+            .limit(limit)
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+    return [_social_post_out(post) for post in posts]
+
+
+@app.post(
+    "/organizations/{org_id}/social-posts",
+    response_model=SocialPostOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_social_post(
+    org_id: int,
+    payload: SocialPostCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SocialPostOut:
+    require_org_admin(db, user, org_id)
+    providers = [target.provider for target in payload.targets]
+    if len(providers) != len(set(providers)):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Choose each social destination only once",
+        )
+    unsupported = [
+        PROVIDER_DETAILS[provider]["name"]
+        for provider in providers
+        if not PROVIDER_DETAILS[provider]["publishing_enabled"]
+    ]
+    if unsupported:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Publishing is not enabled yet for: "
+                f"{', '.join(unsupported)}"
+            ),
+        )
+    if any(
+        not media_url.startswith(("https://", "http://"))
+        for media_url in payload.media_urls
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Media must use a publicly reachable HTTP or HTTPS URL",
+        )
+    if "instagram" in providers and not payload.media_urls:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Instagram requires an uploaded image before publishing",
+        )
+
+    connections = {
+        connection.provider: connection
+        for connection in db.scalars(
+            select(SocialConnection).where(
+                SocialConnection.organization_id == org_id,
+                SocialConnection.provider.in_(providers),
+            )
+        ).all()
+    }
+    unavailable = [
+        PROVIDER_DETAILS[provider]["name"]
+        for provider in providers
+        if provider not in connections
+    ]
+    if unavailable:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Connect these destinations first: {', '.join(unavailable)}",
+        )
+
+    scheduled_at = None
+    post_status = "draft"
+    if payload.scheduled_at:
+        scheduled_at = _as_utc(payload.scheduled_at).replace(tzinfo=None)
+        if scheduled_at <= datetime.utcnow():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Scheduled time must be in the future",
+            )
+        post_status = "scheduled"
+
+    post = SocialPost(
+        organization_id=org_id,
+        master_caption=payload.master_caption,
+        media_urls=payload.media_urls or None,
+        status=post_status,
+        scheduled_at=scheduled_at,
+        created_by=user.id,
+        targets=[
+            SocialPostTarget(
+                provider=target.provider,
+                content=target.content,
+                status="pending",
+            )
+            for target in payload.targets
+        ],
+    )
+    db.add(post)
+    db.commit()
+    db.refresh(post)
+    return _social_post_out(post)
+
+
+@app.post(
+    "/organizations/{org_id}/social-posts/{post_id}/publish",
+    response_model=SocialPostOut,
+)
+def publish_social_post_now(
+    org_id: int,
+    post_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SocialPostOut:
+    require_org_admin(db, user, org_id)
+    post = _load_social_post(
+        db,
+        organization_id=org_id,
+        post_id=post_id,
+    )
+    if post.status == "publishing":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This post is already publishing",
+        )
+    return _social_post_out(_publish_social_post(db, post))
+
+
+def _publish_due_social_posts_once() -> None:
+    with SessionLocal() as db:
+        due_post_ids = list(
+            db.scalars(
+                select(SocialPost.id).where(
+                    SocialPost.status == "scheduled",
+                    SocialPost.scheduled_at.is_not(None),
+                    SocialPost.scheduled_at <= datetime.utcnow(),
+                )
+            ).all()
+        )
+        for post_id in due_post_ids:
+            post = (
+                db.execute(
+                    select(SocialPost)
+                    .options(joinedload(SocialPost.targets))
+                    .where(SocialPost.id == post_id)
+                )
+                .unique()
+                .scalar_one_or_none()
+            )
+            if post and post.status == "scheduled":
+                _publish_social_post(db, post)
+
+
+async def _social_scheduler_loop() -> None:
+    interval = max(10, settings.social_scheduler_interval_seconds)
+    while True:
+        try:
+            await asyncio.to_thread(_publish_due_social_posts_once)
+        except Exception as exc:  # pragma: no cover - production resilience
+            if settings.sentry_dsn:
+                import sentry_sdk
+
+                sentry_sdk.capture_exception(exc)
+        await asyncio.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# Locations
+# ---------------------------------------------------------------------------
+
+
+def _location_out(
+    location: Location,
+    *,
+    membership: OrganizationMember,
+    location_role: LocationRole | None = None,
+) -> LocationOut:
+    is_org_admin = membership.role == Role.ADMIN
+    return LocationOut(
+        id=location.id,
+        organization_id=location.organization_id,
+        name=location.name,
+        address=location.address,
+        timezone=location.timezone,
+        is_default=location.is_default,
+        feedback_token=location.feedback_token,
+        review_links=location.review_links,
+        access_role=_access_role_from_membership(
+            membership,
+            [location_role] if location_role else None,
+        ),
+        can_manage=is_org_admin or location_role == LocationRole.MANAGER,
+        created_at=location.created_at,
+    )
+
+
+@app.get("/organizations/{org_id}/locations", response_model=list[LocationOut])
+def list_locations(
+    org_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[LocationOut]:
+    membership, locations = get_accessible_locations(db, user, org_id)
+    location_roles: dict[int, LocationRole] = {}
+    if membership.role == Role.LOCATION:
+        location_roles = {
+            row.location_id: row.role
+            for row in db.scalars(
+                select(LocationMembership).where(
+                    LocationMembership.user_id == user.id,
+                    LocationMembership.organization_id == org_id,
+                )
+            ).all()
+        }
+    return [
+        _location_out(location, membership=membership, location_role=location_roles.get(location.id))
+        for location in locations
+    ]
+
+
+@app.post("/organizations/{org_id}/locations", response_model=LocationOut, status_code=status.HTTP_201_CREATED)
+def create_location(
+    org_id: int,
+    payload: LocationCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> LocationOut:
+    membership = require_org_admin(db, user, org_id)
+    location = Location(
+        organization_id=org_id,
+        name=payload.name.strip(),
+        address=payload.address.strip() if payload.address else None,
+        timezone=payload.timezone.strip(),
+        feedback_token=generate_feedback_token(),
+        is_default=False,
+        created_by=user.id,
+    )
+    db.add(location)
+    db.commit()
+    db.refresh(location)
+    return _location_out(location, membership=membership)
+
+
+@app.patch("/organizations/{org_id}/locations/{location_id}", response_model=LocationOut)
+def update_location(
+    org_id: int,
+    location_id: int,
+    payload: LocationUpdate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> LocationOut:
+    membership = require_org_admin(db, user, org_id)
+    location = db.scalar(
+        select(Location).where(Location.id == location_id, Location.organization_id == org_id)
+    )
+    if not location:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Location not found")
+    if payload.name is not None:
+        location.name = payload.name.strip()
+    if payload.address is not None:
+        location.address = payload.address.strip() or None
+    if payload.timezone is not None:
+        location.timezone = payload.timezone.strip()
+    db.commit()
+    db.refresh(location)
+    return _location_out(location, membership=membership)
+
+
+@app.patch("/organizations/{org_id}/locations/{location_id}/review-links", response_model=LocationOut)
+def update_location_review_links(
+    org_id: int,
+    location_id: int,
+    payload: LocationReviewLinksUpdate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> LocationOut:
+    membership, location, location_role = require_location_access(
+        db,
+        user,
+        org_id,
+        location_id,
+        manage=True,
+    )
+    location.review_links = [link.model_dump() for link in payload.review_links]
+    if location.is_default:
+        membership.organization.review_links = location.review_links
+    db.commit()
+    db.refresh(location)
+    return _location_out(location, membership=membership, location_role=location_role)
+
+
+@app.delete("/organizations/{org_id}/locations/{location_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_location(
+    org_id: int,
+    location_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    require_org_admin(db, user, org_id)
+    location = db.scalar(
+        select(Location).where(Location.id == location_id, Location.organization_id == org_id)
+    )
+    if not location:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Location not found")
+    if location.is_default:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="The default location cannot be deleted")
+    content_count = sum(
+        int(db.scalar(select(func.count()).select_from(model).where(model.location_id == location_id)) or 0)
+        for model in (Feedback, Initiative, Digest)
+    )
+    if content_count:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Move or delete this location's content before deleting it",
+        )
+    db.delete(location)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
 # Members
 # ---------------------------------------------------------------------------
 
@@ -370,7 +1495,7 @@ def list_members(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[MemberOut]:
-    get_user_org_membership(db, user, org_id)
+    require_org_admin(db, user, org_id)
 
     members = (
         db.execute(
@@ -383,8 +1508,49 @@ def list_members(
         .all()
     )
 
+    assignments = db.scalars(
+        select(LocationMembership).where(LocationMembership.organization_id == org_id)
+    ).all()
+    by_user: dict[int, list[LocationAssignment]] = {}
+    for assignment in assignments:
+        by_user.setdefault(assignment.user_id, []).append(
+            LocationAssignment(location_id=assignment.location_id, role=assignment.role.value)
+        )
+    return [_member_out(member, by_user.get(member.user_id, [])) for member in members]
+
+
+def _member_out(member: OrganizationMember, assignments: list[LocationAssignment]) -> MemberOut:
+    return MemberOut(
+        user_id=member.user.id,
+        email=member.user.email,
+        role=_access_role_from_membership(
+            member,
+            [LocationRole(assignment.role) for assignment in assignments],
+        ),
+        joined_at=member.joined_at,
+        location_assignments=assignments,
+    )
+
+
+def _access_role_configuration(access_role: str) -> tuple[Role, LocationRole | None]:
+    configurations = {
+        "organization_admin": (Role.ADMIN, None),
+        "organization_viewer": (Role.VIEWER, None),
+        "location_admin": (Role.LOCATION, LocationRole.MANAGER),
+        "location_viewer": (Role.LOCATION, LocationRole.VIEWER),
+    }
+    return configurations[access_role]
+
+
+def _member_assignments(db: Session, member: OrganizationMember) -> list[LocationAssignment]:
     return [
-        MemberOut(user_id=m.user.id, email=m.user.email, role=m.role.value, joined_at=m.joined_at) for m in members
+        LocationAssignment(location_id=row.location_id, role=row.role.value)
+        for row in db.scalars(
+            select(LocationMembership).where(
+                LocationMembership.user_id == member.user_id,
+                LocationMembership.organization_id == member.organization_id,
+            )
+        ).all()
     ]
 
 
@@ -406,7 +1572,8 @@ def update_member_role(
     if not member:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
 
-    if member.role == Role.ADMIN and payload.role != "admin":
+    new_membership_role, new_location_role = _access_role_configuration(payload.role)
+    if member.role == Role.ADMIN and new_membership_role != Role.ADMIN:
         admin_count = db.scalar(
             select(func.count()).select_from(OrganizationMember).where(
                 OrganizationMember.organization_id == org_id, OrganizationMember.role == Role.ADMIN
@@ -415,11 +1582,109 @@ def update_member_role(
         if admin_count <= 1:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot remove last admin")
 
-    member.role = Role(payload.role)
+    member.role = new_membership_role
+    if new_membership_role != Role.LOCATION:
+        db.query(LocationMembership).filter(
+            LocationMembership.user_id == user_id,
+            LocationMembership.organization_id == org_id,
+        ).delete(synchronize_session=False)
+    else:
+        current_assignments = db.scalars(
+            select(LocationMembership).where(
+                LocationMembership.user_id == user_id,
+                LocationMembership.organization_id == org_id,
+            )
+        ).all()
+        if current_assignments:
+            for assignment in current_assignments:
+                assignment.role = new_location_role
+        else:
+            default_location = db.scalar(
+                select(Location).where(
+                    Location.organization_id == org_id,
+                    Location.is_default.is_(True),
+                )
+            )
+            if default_location:
+                db.add(
+                    LocationMembership(
+                        user_id=user_id,
+                        organization_id=org_id,
+                        location_id=default_location.id,
+                        role=new_location_role,
+                    )
+                )
     db.commit()
     db.refresh(member)
 
-    return MemberOut(user_id=member.user.id, email=member.user.email, role=member.role.value, joined_at=member.joined_at)
+    return _member_out(member, _member_assignments(db, member))
+
+
+@app.put("/organizations/{org_id}/members/{user_id}/locations", response_model=MemberOut)
+def update_member_location_assignments(
+    org_id: int,
+    user_id: int,
+    payload: MemberLocationAssignmentsUpdate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> MemberOut:
+    require_org_admin(db, user, org_id)
+    member = db.scalar(
+        select(OrganizationMember)
+        .where(
+            OrganizationMember.organization_id == org_id,
+            OrganizationMember.user_id == user_id,
+        )
+        .options(joinedload(OrganizationMember.user))
+    )
+    if not member:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
+    if member.role != Role.LOCATION:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only location-level users can be assigned to individual locations",
+        )
+
+    location_ids = {assignment.location_id for assignment in payload.assignments}
+    valid_location_ids = set(
+        db.scalars(
+            select(Location.id).where(
+                Location.organization_id == org_id,
+                Location.id.in_(location_ids) if location_ids else False,
+            )
+        ).all()
+    )
+    if valid_location_ids != location_ids:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid location assignment")
+    if not payload.assignments:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Assign at least one location")
+
+    expected_location_role = (
+        LocationRole.MANAGER
+        if _access_role_from_membership(
+            member,
+            [LocationRole(assignment.role) for assignment in _member_assignments(db, member)],
+        ) == "location_admin"
+        else LocationRole.VIEWER
+    )
+    if any(assignment.role != expected_location_role.value for assignment in payload.assignments):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Location assignments must match the user's access level")
+
+    db.query(LocationMembership).filter(
+        LocationMembership.user_id == user_id,
+        LocationMembership.organization_id == org_id,
+    ).delete(synchronize_session=False)
+    for assignment in payload.assignments:
+        db.add(
+            LocationMembership(
+                user_id=user_id,
+                organization_id=org_id,
+                location_id=assignment.location_id,
+                role=expected_location_role,
+            )
+        )
+    db.commit()
+    return _member_out(member, payload.assignments)
 
 
 @app.delete("/organizations/{org_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -469,15 +1734,33 @@ def create_invite(
 ) -> InviteOut:
     require_org_admin(db, user, org_id)
 
+    invite_membership_role, invite_location_role = _access_role_configuration(payload.role)
+    invite_location = None
+    if invite_membership_role == Role.LOCATION:
+        if payload.location_id is None:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Choose a location for a location-level invite")
+        invite_location = db.scalar(
+            select(Location).where(
+                Location.id == payload.location_id,
+                Location.organization_id == org_id,
+            )
+        )
+        if not invite_location:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Choose a valid location")
+    elif payload.location_id is not None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Organization-level invites cannot be scoped to one location")
+
     token = generate_invite_token()
     expires_at = datetime.now(timezone.utc) + timedelta(hours=payload.expires_in_hours)
 
     invite = Invite(
         organization_id=org_id,
         token=token,
-        role=Role(payload.role),
+        role=invite_membership_role,
         created_by=user.id,
         expires_at=expires_at,
+        location_id=invite_location.id if invite_location else None,
+        location_role=invite_location_role,
     )
     db.add(invite)
     db.commit()
@@ -488,11 +1771,17 @@ def create_invite(
     return InviteOut(
         id=invite.id,
         token=invite.token,
-        role=invite.role.value,
+        role=_access_role_from_membership(
+            invite,
+            [invite.location_role] if invite.location_role else None,
+        ),
         created_at=invite.created_at,
         expires_at=invite.expires_at,
         used_at=invite.used_at,
         invite_url=invite_url,
+        location_id=invite.location_id,
+        location_name=invite_location.name if invite_location else None,
+        location_role=invite.location_role.value if invite.location_role else None,
     )
 
 
@@ -505,18 +1794,27 @@ def list_invites(
     require_org_admin(db, user, org_id)
 
     invites = db.scalars(
-        select(Invite).where(Invite.organization_id == org_id).order_by(Invite.created_at.desc())
+        select(Invite)
+        .where(Invite.organization_id == org_id)
+        .options(joinedload(Invite.location))
+        .order_by(Invite.created_at.desc())
     ).all()
 
     return [
         InviteOut(
             id=inv.id,
             token=inv.token,
-            role=inv.role.value,
+            role=_access_role_from_membership(
+                inv,
+                [inv.location_role] if inv.location_role else None,
+            ),
             created_at=inv.created_at,
             expires_at=inv.expires_at,
             used_at=inv.used_at,
             invite_url=f"{settings.frontend_origin}/invite/{inv.token}",
+            location_id=inv.location_id,
+            location_name=inv.location.name if inv.location else None,
+            location_role=inv.location_role.value if inv.location_role else None,
         )
         for inv in invites
     ]
@@ -535,8 +1833,13 @@ def get_invite_info(token: str, db: Session = Depends(get_db)) -> InviteInfo:
 
     return InviteInfo(
         organization_name=invite.organization.name,
-        role=invite.role.value,
+        role=_access_role_from_membership(
+            invite,
+            [invite.location_role] if invite.location_role else None,
+        ),
         expires_at=invite.expires_at,
+        location_name=invite.location.name if invite.location else None,
+        location_role=invite.location_role.value if invite.location_role else None,
     )
 
 
@@ -561,30 +1864,45 @@ def accept_invite(
             OrganizationMember.organization_id == invite.organization_id,
         )
     )
-    if existing:
+    if existing and invite.location_id is None:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already a member of this organization")
 
-    membership = OrganizationMember(
-        user_id=user.id,
-        organization_id=invite.organization_id,
-        role=invite.role,
-    )
-    db.add(membership)
+    membership = existing
+    if not membership:
+        membership = OrganizationMember(
+            user_id=user.id,
+            organization_id=invite.organization_id,
+            role=invite.role,
+        )
+        db.add(membership)
+        db.flush()
+
+    if invite.location_id is not None:
+        if membership.role != Role.LOCATION:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="This user already has organization-wide access")
+        existing_location_access = db.scalar(
+            select(LocationMembership).where(
+                LocationMembership.user_id == user.id,
+                LocationMembership.location_id == invite.location_id,
+            )
+        )
+        if existing_location_access:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already assigned to this location")
+        db.add(
+            LocationMembership(
+                user_id=user.id,
+                organization_id=invite.organization_id,
+                location_id=invite.location_id,
+                role=invite.location_role or LocationRole.VIEWER,
+            )
+        )
 
     invite.used_at = datetime.now(timezone.utc)
     invite.used_by = user.id
 
     db.commit()
 
-    return OrganizationOut(
-        id=invite.organization.id,
-        name=invite.organization.name,
-        created_at=invite.organization.created_at,
-        created_by=invite.organization.created_by,
-        role=membership.role.value,
-        feedback_token=invite.organization.feedback_token,
-review_links=invite.organization.review_links,
-    )
+    return _organization_out(db, membership)
 
 
 # ---------------------------------------------------------------------------
@@ -592,27 +1910,51 @@ review_links=invite.organization.review_links,
 # ---------------------------------------------------------------------------
 
 
+def _get_public_location(db: Session, feedback_token: str) -> Location:
+    location = db.scalar(
+        select(Location)
+        .where(Location.feedback_token == feedback_token)
+        .options(joinedload(Location.organization))
+    )
+    if location:
+        return location
+
+    legacy_org = db.scalar(select(Organization).where(Organization.feedback_token == feedback_token))
+    if legacy_org:
+        location = db.scalar(
+            select(Location)
+            .where(Location.organization_id == legacy_org.id, Location.is_default.is_(True))
+            .options(joinedload(Location.organization))
+        )
+    if not location:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Feedback form not found")
+    return location
+
+
 @app.get("/api/feedback/{feedback_token}", response_model=FeedbackFormInfo)
 def get_feedback_form_info(feedback_token: str, db: Session = Depends(get_db)) -> FeedbackFormInfo:
-    """Public endpoint - get org info for feedback form"""
-    org = db.scalar(select(Organization).where(Organization.feedback_token == feedback_token))
-    if not org:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Feedback form not found")
-    return FeedbackFormInfo(organization_name=org.name, organization_id=org.id, review_links=org.review_links)
+    """Public endpoint - get location info for feedback form."""
+    location = _get_public_location(db, feedback_token)
+    return FeedbackFormInfo(
+        organization_name=location.organization.name,
+        organization_id=location.organization_id,
+        location_name=location.name,
+        location_id=location.id,
+        review_links=location.review_links,
+    )
 
 
 @app.post("/api/feedback/{feedback_token}/submit", response_model=FeedbackSubmitResponse, status_code=status.HTTP_201_CREATED)
 @limiter.limit("10/minute")
 def submit_feedback(request: Request, feedback_token: str, payload: FeedbackSubmit, db: Session = Depends(get_db)) -> FeedbackSubmitResponse:
     """Public endpoint - submit anonymous feedback"""
-    org = db.scalar(select(Organization).where(Organization.feedback_token == feedback_token))
-    if not org:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Feedback form not found")
+    location = _get_public_location(db, feedback_token)
 
     is_anonymous = not payload.submitter_email and not payload.submitter_name
 
     feedback = Feedback(
-        organization_id=org.id,
+        organization_id=location.organization_id,
+        location_id=location.id,
         content=payload.content,
         submitter_email=payload.submitter_email.lower() if payload.submitter_email else None,
         submitter_name=payload.submitter_name,
@@ -633,9 +1975,7 @@ def polish_feedback_for_review(
     db: Session = Depends(get_db),
 ) -> ReviewPolishResponse:
     """Public endpoint - AI-polish feedback text into a public review draft."""
-    org = db.scalar(select(Organization).where(Organization.feedback_token == feedback_token))
-    if not org:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Feedback form not found")
+    _get_public_location(db, feedback_token)
 
     if not settings.openai_api_key:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="AI not configured")
@@ -651,15 +1991,291 @@ def polish_feedback_for_review(
 @app.get("/organizations/{org_id}/feedback", response_model=list[FeedbackOut])
 def list_organization_feedback(
     org_id: int,
+    location_id: int | None = Query(default=None),
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[FeedbackOut]:
-    """Admin-only endpoint to list feedback (not exposed in UI yet)"""
-    require_org_admin(db, user, org_id)
+    """List feedback across the caller's authorized location scope."""
+    _, locations = resolve_location_scope(db, user, org_id, location_id, manage=True)
+    location_ids = [location.id for location in locations]
     feedback_list = db.scalars(
-        select(Feedback).where(Feedback.organization_id == org_id).order_by(Feedback.created_at.desc())
+        select(Feedback)
+        .where(
+            Feedback.organization_id == org_id,
+            Feedback.location_id.in_(location_ids),
+        )
+        .order_by(Feedback.created_at.desc())
     ).all()
     return [FeedbackOut.model_validate(f, from_attributes=True) for f in feedback_list]
+
+
+# ---------------------------------------------------------------------------
+# Organization voting board
+# ---------------------------------------------------------------------------
+
+
+def _valid_visitor_id(visitor_id: str | None, *, required: bool = False) -> str | None:
+    """Validate the browser-scoped identifier used for anonymous votes."""
+    normalized = (visitor_id or "").strip()
+    if not normalized:
+        if required:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing visitor identifier")
+        return None
+    if (
+        len(normalized) < 16
+        or len(normalized) > 64
+        or any(not (character.isalnum() or character in "-_") for character in normalized)
+    ):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid visitor identifier")
+    return normalized
+
+
+def _initiative_rows_query(
+    organization_id: int,
+    visitor_id: str | None = None,
+    location_ids: list[int] | None = None,
+):
+    vote_totals = (
+        select(
+            InitiativeVote.initiative_id.label("initiative_id"),
+            func.coalesce(func.sum(case((InitiativeVote.value == 1, 1), else_=0)), 0).label("upvotes"),
+            func.coalesce(func.sum(case((InitiativeVote.value == -1, 1), else_=0)), 0).label("downvotes"),
+        )
+        .group_by(InitiativeVote.initiative_id)
+        .subquery()
+    )
+    viewer_vote = (
+        select(InitiativeVote.value)
+        .where(
+            InitiativeVote.initiative_id == Initiative.id,
+            InitiativeVote.visitor_id == (visitor_id or ""),
+        )
+        .scalar_subquery()
+    )
+    query = (
+        select(
+            Initiative,
+            func.coalesce(vote_totals.c.upvotes, 0).label("upvotes"),
+            func.coalesce(vote_totals.c.downvotes, 0).label("downvotes"),
+            viewer_vote.label("viewer_vote"),
+        )
+        .outerjoin(vote_totals, vote_totals.c.initiative_id == Initiative.id)
+        .where(Initiative.organization_id == organization_id)
+    )
+    if location_ids is not None:
+        query = query.where(Initiative.location_id.in_(location_ids))
+    return query
+
+
+def _initiative_out(row, *, include_viewer_vote: bool) -> InitiativeOut | PublicInitiativeOut:
+    initiative, upvotes, downvotes, viewer_vote = row
+    values = {
+        "id": initiative.id,
+        "organization_id": initiative.organization_id,
+        "location_id": initiative.location_id,
+        "location_name": initiative.location.name,
+        "title": initiative.title,
+        "description": initiative.description,
+        "status": initiative.status.value,
+        "created_at": initiative.created_at,
+        "updated_at": initiative.updated_at,
+        "upvotes": int(upvotes),
+        "downvotes": int(downvotes),
+        "score": int(upvotes) - int(downvotes),
+    }
+    if include_viewer_vote:
+        values["viewer_vote"] = int(viewer_vote) if viewer_vote is not None else None
+        return PublicInitiativeOut(**values)
+    return InitiativeOut(**values)
+
+
+def _get_initiative_or_404(
+    db: Session,
+    org_id: int,
+    initiative_id: int,
+    location_ids: list[int] | None = None,
+) -> Initiative:
+    query = select(Initiative).where(
+        Initiative.id == initiative_id,
+        Initiative.organization_id == org_id,
+    )
+    if location_ids is not None:
+        query = query.where(Initiative.location_id.in_(location_ids))
+    initiative = db.scalar(
+        query
+    )
+    if not initiative:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Initiative not found")
+    return initiative
+
+
+def _clean_initiative_text(value: str, field_name: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"{field_name} cannot be blank")
+    return cleaned
+
+
+@app.get("/organizations/{org_id}/initiatives", response_model=list[InitiativeOut])
+def list_organization_initiatives(
+    org_id: int,
+    location_id: int | None = Query(default=None),
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[InitiativeOut]:
+    _, locations = resolve_location_scope(db, user, org_id, location_id)
+    location_ids = [location.id for location in locations]
+    rows = db.execute(
+        _initiative_rows_query(org_id, location_ids=location_ids).order_by(Initiative.updated_at.desc())
+    ).all()
+    return [_initiative_out(row, include_viewer_vote=False) for row in rows]
+
+
+@app.post("/organizations/{org_id}/initiatives", response_model=InitiativeOut, status_code=status.HTTP_201_CREATED)
+def create_organization_initiative(
+    org_id: int,
+    payload: InitiativeCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> InitiativeOut:
+    _, locations = resolve_location_scope(
+        db,
+        user,
+        org_id,
+        payload.location_id,
+        manage=True,
+        require_single=True,
+    )
+    location = locations[0]
+    initiative = Initiative(
+        organization_id=org_id,
+        location_id=location.id,
+        title=_clean_initiative_text(payload.title, "Title"),
+        description=_clean_initiative_text(payload.description, "Description"),
+        status=InitiativeStatus(payload.status),
+    )
+    db.add(initiative)
+    db.commit()
+    row = db.execute(
+        _initiative_rows_query(org_id, location_ids=[location.id]).where(Initiative.id == initiative.id)
+    ).one()
+    return _initiative_out(row, include_viewer_vote=False)
+
+
+@app.patch("/organizations/{org_id}/initiatives/{initiative_id}", response_model=InitiativeOut)
+def update_organization_initiative(
+    org_id: int,
+    initiative_id: int,
+    payload: InitiativeUpdate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> InitiativeOut:
+    initiative = _get_initiative_or_404(db, org_id, initiative_id)
+    require_location_access(db, user, org_id, initiative.location_id, manage=True)
+    if payload.title is not None:
+        initiative.title = _clean_initiative_text(payload.title, "Title")
+    if payload.description is not None:
+        initiative.description = _clean_initiative_text(payload.description, "Description")
+    if payload.status is not None:
+        initiative.status = InitiativeStatus(payload.status)
+    db.commit()
+    row = db.execute(
+        _initiative_rows_query(org_id, location_ids=[initiative.location_id]).where(Initiative.id == initiative_id)
+    ).one()
+    return _initiative_out(row, include_viewer_vote=False)
+
+
+@app.delete("/organizations/{org_id}/initiatives/{initiative_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_organization_initiative(
+    org_id: int,
+    initiative_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    initiative = _get_initiative_or_404(db, org_id, initiative_id)
+    require_location_access(db, user, org_id, initiative.location_id, manage=True)
+    db.delete(initiative)
+    db.commit()
+
+
+@app.get("/api/boards/{feedback_token}", response_model=BoardOut)
+def get_public_board(
+    feedback_token: str,
+    q: str = Query(default="", max_length=160),
+    status_filter: InitiativeStatus | None = Query(default=None, alias="status"),
+    sort: str = Query(default="top", pattern="^(top|new|updated)$"),
+    visitor_id: str | None = Header(default=None, alias="X-Visitor-ID"),
+    db: Session = Depends(get_db),
+) -> BoardOut:
+    location = _get_public_location(db, feedback_token)
+    org = location.organization
+
+    visitor_id = _valid_visitor_id(visitor_id)
+    query = _initiative_rows_query(org.id, visitor_id, [location.id])
+    trimmed_query = q.strip()
+    if trimmed_query:
+        search_pattern = f"%{trimmed_query}%"
+        query = query.where(
+            Initiative.title.ilike(search_pattern) | Initiative.description.ilike(search_pattern)
+        )
+    if status_filter is not None:
+        query = query.where(Initiative.status == status_filter)
+
+    score = func.coalesce(
+        select(func.sum(InitiativeVote.value)).where(InitiativeVote.initiative_id == Initiative.id).scalar_subquery(),
+        0,
+    )
+    if sort == "new":
+        query = query.order_by(Initiative.created_at.desc())
+    elif sort == "updated":
+        query = query.order_by(Initiative.updated_at.desc())
+    else:
+        query = query.order_by(score.desc(), Initiative.updated_at.desc())
+
+    rows = db.execute(query).all()
+    return BoardOut(
+        organization_name=org.name,
+        organization_id=org.id,
+        location_name=location.name,
+        location_id=location.id,
+        initiatives=[_initiative_out(row, include_viewer_vote=True) for row in rows],
+    )
+
+
+@app.put("/api/boards/{feedback_token}/initiatives/{initiative_id}/vote", response_model=PublicInitiativeOut)
+@limiter.limit("60/minute")
+def update_public_initiative_vote(
+    request: Request,
+    feedback_token: str,
+    initiative_id: int,
+    payload: InitiativeVoteUpdate,
+    visitor_id: str | None = Header(default=None, alias="X-Visitor-ID"),
+    db: Session = Depends(get_db),
+) -> PublicInitiativeOut:
+    location = _get_public_location(db, feedback_token)
+    org = location.organization
+    visitor_id = _valid_visitor_id(visitor_id, required=True)
+    _get_initiative_or_404(db, org.id, initiative_id, [location.id])
+
+    vote = db.scalar(
+        select(InitiativeVote).where(
+            InitiativeVote.initiative_id == initiative_id,
+            InitiativeVote.visitor_id == visitor_id,
+        )
+    )
+    if payload.value is None:
+        if vote:
+            db.delete(vote)
+    elif vote:
+        vote.value = payload.value
+    else:
+        db.add(InitiativeVote(initiative_id=initiative_id, visitor_id=visitor_id, value=payload.value))
+    db.commit()
+
+    row = db.execute(
+        _initiative_rows_query(org.id, visitor_id, [location.id]).where(Initiative.id == initiative_id)
+    ).one()
+    return _initiative_out(row, include_viewer_vote=True)
 
 
 # ---------------------------------------------------------------------------
@@ -671,29 +2287,42 @@ def list_organization_feedback(
 def get_feedback_stats(
     org_id: int,
     days: int = Query(default=7, ge=1, le=365),
+    location_id: int | None = Query(default=None),
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> FeedbackStatsOut:
     """Return daily feedback submission counts over the past N days (zero-filled)."""
-    get_user_org_membership(db, user, org_id)
-
-    since = datetime.now(timezone.utc) - timedelta(days=days)
+    _, locations = resolve_location_scope(db, user, org_id, location_id)
+    location_ids = [location.id for location in locations]
+    location_timezones = {
+        location.id: _location_timezone(location)
+        for location in locations
+    }
+    display_timezone = _location_timezone(locations[0])
+    today = datetime.now(display_timezone).date()
+    first_day = today - timedelta(days=days - 1)
+    since = min(
+        datetime.combine(first_day, time.min, tzinfo=location_timezone)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+        for location_timezone in location_timezones.values()
+    )
 
     rows = db.execute(
-        select(
-            func.date(Feedback.created_at).label("day"),
-            func.count(Feedback.id).label("cnt"),
-        )
+        select(Feedback.created_at, Feedback.location_id)
         .where(Feedback.organization_id == org_id)
+        .where(Feedback.location_id.in_(location_ids))
         .where(Feedback.created_at >= since)
-        .group_by(func.date(Feedback.created_at))
-        .order_by(func.date(Feedback.created_at))
+        .order_by(Feedback.created_at)
     ).all()
 
-    # Build a zero-filled lookup
-    counts: dict[str, int] = {str(row.day): row.cnt for row in rows}
+    counts: dict[str, int] = {}
+    for created_at, row_location_id in rows:
+        local_day = _as_utc(created_at).astimezone(location_timezones[row_location_id]).date()
+        if first_day <= local_day <= today:
+            day_key = local_day.isoformat()
+            counts[day_key] = counts.get(day_key, 0) + 1
 
-    today = date.today()
     result: list[FeedbackStatPoint] = []
     for i in range(days - 1, -1, -1):
         day = today - timedelta(days=i)
@@ -716,8 +2345,16 @@ def generate_digest(
     db: Session = Depends(get_db),
 ) -> DigestOut:
     """Admin triggers AI generation of a digest for a date range."""
-    membership = require_org_admin(db, user, org_id)
+    membership, locations = resolve_location_scope(
+        db,
+        user,
+        org_id,
+        payload.location_id,
+        manage=True,
+        require_single=True,
+    )
     org = membership.organization
+    location = locations[0]
 
     if not settings.openai_api_key:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="AI generation not configured")
@@ -725,12 +2362,25 @@ def generate_digest(
     if payload.period_start > payload.period_end:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="period_start must be on or before period_end")
 
-    # Fetch feedback in the date range (inclusive)
+    location_timezone = _location_timezone(location)
+    period_start_utc = (
+        datetime.combine(payload.period_start, time.min, tzinfo=location_timezone)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
+    period_end_utc = (
+        datetime.combine(payload.period_end + timedelta(days=1), time.min, tzinfo=location_timezone)
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
+
+    # Fetch feedback in the location's local date range (inclusive).
     feedback_rows = db.scalars(
         select(Feedback)
         .where(Feedback.organization_id == org_id)
-        .where(func.date(Feedback.created_at) >= payload.period_start)
-        .where(func.date(Feedback.created_at) <= payload.period_end)
+        .where(Feedback.location_id == location.id)
+        .where(Feedback.created_at >= period_start_utc)
+        .where(Feedback.created_at < period_end_utc)
         .order_by(Feedback.created_at)
     ).all()
 
@@ -751,6 +2401,7 @@ def generate_digest(
 
     digest = Digest(
         organization_id=org_id,
+        location_id=location.id,
         status=DigestStatus.DRAFT,
         period_start=payload.period_start,
         period_end=payload.period_end,
@@ -770,16 +2421,39 @@ def generate_digest(
 @app.get("/organizations/{org_id}/digests", response_model=list[DigestOut])
 def list_digests(
     org_id: int,
+    location_id: int | None = Query(default=None),
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[DigestOut]:
-    """Admins see all digests; non-admins see only published ones."""
-    membership = get_user_org_membership(db, user, org_id)
+    """Organization admins and location managers see drafts in the locations they manage."""
+    membership, locations = resolve_location_scope(db, user, org_id, location_id)
     is_admin = membership.role == Role.ADMIN
+    location_ids = [location.id for location in locations]
 
-    query = select(Digest).where(Digest.organization_id == org_id)
+    query = select(Digest).where(
+        Digest.organization_id == org_id,
+        Digest.location_id.in_(location_ids),
+    )
     if not is_admin:
-        query = query.where(Digest.status == DigestStatus.PUBLISHED)
+        manager_location_ids = list(
+            db.scalars(
+                select(LocationMembership.location_id).where(
+                    LocationMembership.user_id == user.id,
+                    LocationMembership.organization_id == org_id,
+                    LocationMembership.location_id.in_(location_ids),
+                    LocationMembership.role == LocationRole.MANAGER,
+                )
+            ).all()
+        )
+        if manager_location_ids:
+            query = query.where(
+                or_(
+                    Digest.status == DigestStatus.PUBLISHED,
+                    Digest.location_id.in_(manager_location_ids),
+                )
+            )
+        else:
+            query = query.where(Digest.status == DigestStatus.PUBLISHED)
     query = query.order_by(Digest.generated_at.desc())
 
     digests = db.scalars(query).all()
@@ -793,7 +2467,7 @@ def get_digest(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> DigestOut:
-    """Get a single digest. Non-admins can only see published ones."""
+    """Get a single digest, including drafts for its location managers."""
     membership = get_user_org_membership(db, user, org_id)
     is_admin = membership.role == Role.ADMIN
 
@@ -803,7 +2477,10 @@ def get_digest(
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
 
-    if not is_admin and digest.status != DigestStatus.PUBLISHED:
+    _, _, location_role = require_location_access(db, user, org_id, digest.location_id)
+
+    can_view_draft = is_admin or location_role == LocationRole.MANAGER
+    if not can_view_draft and digest.status != DigestStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
 
     return DigestOut.model_validate(digest)
@@ -818,13 +2495,12 @@ def update_digest(
     db: Session = Depends(get_db),
 ) -> DigestOut:
     """Admin can edit a draft digest. Published digests are immutable."""
-    require_org_admin(db, user, org_id)
-
     digest = db.scalar(
         select(Digest).where(Digest.id == digest_id, Digest.organization_id == org_id)
     )
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
+    require_location_access(db, user, org_id, digest.location_id, manage=True)
 
     if digest.status == DigestStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Published digests cannot be edited")
@@ -851,13 +2527,12 @@ def publish_digest(
     db: Session = Depends(get_db),
 ) -> DigestOut:
     """Admin publishes a draft digest, making it visible to all org members."""
-    require_org_admin(db, user, org_id)
-
     digest = db.scalar(
         select(Digest).where(Digest.id == digest_id, Digest.organization_id == org_id)
     )
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
+    require_location_access(db, user, org_id, digest.location_id, manage=True)
 
     if digest.status == DigestStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Digest is already published")
@@ -879,13 +2554,12 @@ def delete_digest(
     db: Session = Depends(get_db),
 ) -> None:
     """Admin deletes a digest (draft or published)."""
-    require_org_admin(db, user, org_id)
-
     digest = db.scalar(
         select(Digest).where(Digest.id == digest_id, Digest.organization_id == org_id)
     )
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
+    require_location_access(db, user, org_id, digest.location_id, manage=True)
 
     db.delete(digest)
     db.commit()
@@ -896,7 +2570,12 @@ def serve_frontend(full_path: str) -> FileResponse:
     if not FRONTEND_DIST_DIR.exists():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Frontend assets not available")
 
-    if any(full_path == prefix or full_path.startswith(f"{prefix}/") for prefix in RESERVED_PATH_PREFIXES):
+    # `/auth` is the SPA's login/signup screen, while `/auth/*` remains reserved
+    # for the backend authentication API.
+    if full_path != "auth" and any(
+        full_path == prefix or full_path.startswith(f"{prefix}/")
+        for prefix in RESERVED_PATH_PREFIXES
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
 
     asset_path = (FRONTEND_DIST_DIR / full_path).resolve()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 import enum
 from datetime import date, datetime
 
-from sqlalchemy import Boolean, Date, DateTime, Enum as SQLEnum, ForeignKey, Integer, JSON, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, CheckConstraint, Date, DateTime, Enum as SQLEnum, ForeignKey, ForeignKeyConstraint, Integer, JSON, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .database import Base
@@ -10,11 +10,24 @@ from .database import Base
 class Role(str, enum.Enum):
     ADMIN = "admin"
     VIEWER = "viewer"
+    LOCATION = "location"
+
+
+class LocationRole(str, enum.Enum):
+    MANAGER = "manager"
+    VIEWER = "viewer"
 
 
 class DigestStatus(str, enum.Enum):
     DRAFT = "draft"
     PUBLISHED = "published"
+
+
+class InitiativeStatus(str, enum.Enum):
+    GATHERING_FEEDBACK = "gathering_feedback"
+    PLANNED = "planned"
+    IN_PROGRESS = "in_progress"
+    SHIPPED = "shipped"
 
 
 class User(Base):
@@ -26,6 +39,7 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
     memberships: Mapped[list["OrganizationMember"]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    location_memberships: Mapped[list["LocationMembership"]] = relationship(back_populates="user", cascade="all, delete-orphan")
 
 
 class Organization(Base):
@@ -42,6 +56,24 @@ class Organization(Base):
     invites: Mapped[list["Invite"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
     feedback: Mapped[list["Feedback"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
     digests: Mapped[list["Digest"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
+    initiatives: Mapped[list["Initiative"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
+    locations: Mapped[list["Location"]] = relationship(back_populates="organization", cascade="all, delete-orphan")
+    social_connections: Mapped[list["SocialConnection"]] = relationship(
+        back_populates="organization",
+        cascade="all, delete-orphan",
+    )
+    social_oauth_states: Mapped[list["SocialOAuthState"]] = relationship(
+        back_populates="organization",
+        cascade="all, delete-orphan",
+    )
+    social_connection_setups: Mapped[list["SocialConnectionSetup"]] = relationship(
+        back_populates="organization",
+        cascade="all, delete-orphan",
+    )
+    social_posts: Mapped[list["SocialPost"]] = relationship(
+        back_populates="organization",
+        cascade="all, delete-orphan",
+    )
     creator: Mapped["User"] = relationship(foreign_keys=[created_by])
 
 
@@ -51,14 +83,101 @@ class OrganizationMember(Base):
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id"), nullable=False)
-    role: Mapped[Role] = mapped_column(SQLEnum(Role), nullable=False)
+    role: Mapped[Role] = mapped_column(
+        SQLEnum(Role, values_callable=lambda enum_class: [member.value for member in enum_class]),
+        nullable=False,
+    )
     joined_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
     user: Mapped["User"] = relationship(back_populates="memberships")
     organization: Mapped["Organization"] = relationship(back_populates="members")
+    location_memberships: Mapped[list["LocationMembership"]] = relationship(
+        back_populates="organization_membership",
+        cascade="all, delete-orphan",
+        overlaps="location_memberships,user",
+    )
 
     __table_args__ = (
         UniqueConstraint("user_id", "organization_id", name="uq_user_organization"),
+    )
+
+
+class Location(Base):
+    __tablename__ = "locations"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    organization_id: Mapped[int] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    address: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    timezone: Mapped[str] = mapped_column(String(64), nullable=False, default="America/Chicago")
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    feedback_token: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    review_links: Mapped[list | None] = mapped_column(JSON, nullable=True, default=None)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+
+    organization: Mapped["Organization"] = relationship(back_populates="locations")
+    creator: Mapped["User"] = relationship(foreign_keys=[created_by])
+    memberships: Mapped[list["LocationMembership"]] = relationship(
+        back_populates="location",
+        cascade="all, delete-orphan",
+        overlaps="location_memberships,organization_membership",
+    )
+    feedback: Mapped[list["Feedback"]] = relationship(back_populates="location")
+    initiatives: Mapped[list["Initiative"]] = relationship(back_populates="location")
+    digests: Mapped[list["Digest"]] = relationship(back_populates="location")
+
+    __table_args__ = (
+        UniqueConstraint("id", "organization_id", name="uq_location_id_organization"),
+    )
+
+
+class LocationMembership(Base):
+    __tablename__ = "location_memberships"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    organization_id: Mapped[int] = mapped_column(nullable=False)
+    location_id: Mapped[int] = mapped_column(nullable=False, index=True)
+    role: Mapped[LocationRole] = mapped_column(
+        SQLEnum(
+            LocationRole,
+            name="location_role",
+            values_callable=lambda enum_class: [member.value for member in enum_class],
+        ),
+        nullable=False,
+        default=LocationRole.VIEWER,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user: Mapped["User"] = relationship(back_populates="location_memberships", overlaps="location_memberships,organization_membership")
+    location: Mapped["Location"] = relationship(
+        back_populates="memberships",
+        overlaps="location_memberships,organization_membership",
+    )
+    organization_membership: Mapped["OrganizationMember"] = relationship(
+        back_populates="location_memberships",
+        overlaps="location,location_memberships,memberships,user",
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id", "organization_id"],
+            ["organization_members.user_id", "organization_members.organization_id"],
+            ondelete="CASCADE",
+            name="fk_location_membership_organization_member",
+        ),
+        ForeignKeyConstraint(
+            ["location_id", "organization_id"],
+            ["locations.id", "locations.organization_id"],
+            ondelete="CASCADE",
+            name="fk_location_membership_location",
+        ),
+        UniqueConstraint("user_id", "location_id", name="uq_user_location"),
     )
 
 
@@ -68,16 +187,29 @@ class Invite(Base):
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id"), nullable=False)
     token: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
-    role: Mapped[Role] = mapped_column(SQLEnum(Role), nullable=False)
+    role: Mapped[Role] = mapped_column(
+        SQLEnum(Role, values_callable=lambda enum_class: [member.value for member in enum_class]),
+        nullable=False,
+    )
     created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
     used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     used_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    location_id: Mapped[int | None] = mapped_column(ForeignKey("locations.id", ondelete="CASCADE"), nullable=True)
+    location_role: Mapped[LocationRole | None] = mapped_column(
+        SQLEnum(
+            LocationRole,
+            name="location_role",
+            values_callable=lambda enum_class: [member.value for member in enum_class],
+        ),
+        nullable=True,
+    )
 
     organization: Mapped["Organization"] = relationship(back_populates="invites")
     creator: Mapped["User"] = relationship(foreign_keys=[created_by])
     redeemer: Mapped["User | None"] = relationship(foreign_keys=[used_by])
+    location: Mapped["Location | None"] = relationship()
 
 
 class Feedback(Base):
@@ -85,6 +217,7 @@ class Feedback(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id"), nullable=False)
+    location_id: Mapped[int] = mapped_column(ForeignKey("locations.id", ondelete="RESTRICT"), nullable=False, index=True)
     content: Mapped[str] = mapped_column(String, nullable=False)
     submitter_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     submitter_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -92,6 +225,50 @@ class Feedback(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
     organization: Mapped["Organization"] = relationship(back_populates="feedback")
+    location: Mapped["Location"] = relationship(back_populates="feedback")
+
+
+class Initiative(Base):
+    __tablename__ = "initiatives"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True)
+    location_id: Mapped[int] = mapped_column(ForeignKey("locations.id", ondelete="RESTRICT"), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(160), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[InitiativeStatus] = mapped_column(
+        SQLEnum(
+            InitiativeStatus,
+            name="initiative_status",
+            values_callable=lambda enum_class: [member.value for member in enum_class],
+        ),
+        nullable=False,
+        default=InitiativeStatus.GATHERING_FEEDBACK,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    organization: Mapped["Organization"] = relationship(back_populates="initiatives")
+    location: Mapped["Location"] = relationship(back_populates="initiatives")
+    votes: Mapped[list["InitiativeVote"]] = relationship(back_populates="initiative", cascade="all, delete-orphan")
+
+
+class InitiativeVote(Base):
+    __tablename__ = "initiative_votes"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    initiative_id: Mapped[int] = mapped_column(ForeignKey("initiatives.id", ondelete="CASCADE"), nullable=False, index=True)
+    visitor_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    value: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    initiative: Mapped["Initiative"] = relationship(back_populates="votes")
+
+    __table_args__ = (
+        UniqueConstraint("initiative_id", "visitor_id", name="uq_initiative_vote_visitor"),
+        CheckConstraint("value IN (-1, 1)", name="ck_initiative_vote_value"),
+    )
 
 
 class Digest(Base):
@@ -99,6 +276,7 @@ class Digest(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id"), nullable=False)
+    location_id: Mapped[int] = mapped_column(ForeignKey("locations.id", ondelete="RESTRICT"), nullable=False, index=True)
     status: Mapped[DigestStatus] = mapped_column(SQLEnum(DigestStatus), nullable=False, default=DigestStatus.DRAFT)
     period_start: Mapped[date] = mapped_column(Date, nullable=False)
     period_end: Mapped[date] = mapped_column(Date, nullable=False)
@@ -113,8 +291,13 @@ class Digest(Base):
     published_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
 
     organization: Mapped["Organization"] = relationship(back_populates="digests")
+    location: Mapped["Location"] = relationship(back_populates="digests")
     generator: Mapped["User"] = relationship(foreign_keys=[generated_by])
     publisher: Mapped["User | None"] = relationship(foreign_keys=[published_by])
+
+    @property
+    def location_name(self) -> str:
+        return self.location.name
 
 
 class PasswordResetToken(Base):
@@ -127,3 +310,144 @@ class PasswordResetToken(Base):
     used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     user: Mapped["User"] = relationship()
+
+
+class SocialConnection(Base):
+    __tablename__ = "social_connections"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    organization_id: Mapped[int] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="connected")
+    provider_account_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    provider_account_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    access_token_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    refresh_token_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scopes: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    provider_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    connected_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    organization: Mapped["Organization"] = relationship(back_populates="social_connections")
+    connected_user: Mapped["User"] = relationship(foreign_keys=[connected_by])
+
+    __table_args__ = (
+        UniqueConstraint("organization_id", "provider", name="uq_social_connection_org_provider"),
+    )
+
+
+class SocialOAuthState(Base):
+    __tablename__ = "social_oauth_states"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    state_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    organization_id: Mapped[int] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    organization: Mapped["Organization"] = relationship(back_populates="social_oauth_states")
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+
+
+class SocialConnectionSetup(Base):
+    __tablename__ = "social_connection_setups"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    organization_id: Mapped[int] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    access_token_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    scopes: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    organization: Mapped["Organization"] = relationship(
+        back_populates="social_connection_setups",
+    )
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+
+
+class SocialPost(Base):
+    __tablename__ = "social_posts"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    organization_id: Mapped[int] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    master_caption: Mapped[str] = mapped_column(Text, nullable=False)
+    media_urls: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="draft")
+    scheduled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    organization: Mapped["Organization"] = relationship(back_populates="social_posts")
+    creator: Mapped["User"] = relationship(foreign_keys=[created_by])
+    targets: Mapped[list["SocialPostTarget"]] = relationship(
+        back_populates="post",
+        cascade="all, delete-orphan",
+        order_by="SocialPostTarget.id",
+    )
+
+
+class SocialPostTarget(Base):
+    __tablename__ = "social_post_targets"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    post_id: Mapped[int] = mapped_column(
+        ForeignKey("social_posts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="pending")
+    remote_post_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    post: Mapped["SocialPost"] = relationship(back_populates="targets")
+
+    __table_args__ = (
+        UniqueConstraint("post_id", "provider", name="uq_social_post_target_provider"),
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,5 @@
 from datetime import date as Date, datetime
+from typing import Literal
 
 from pydantic import BaseModel, EmailStr, Field
 
@@ -66,6 +67,50 @@ class OrganizationOut(BaseModel):
     role: str
     feedback_token: str
     review_links: list[ReviewLink] | None = None
+    can_view_all_locations: bool = False
+    can_manage_organization: bool = False
+
+
+# Location schemas
+
+
+class LocationCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    address: str | None = Field(None, max_length=500)
+    timezone: str = Field(default="America/Chicago", min_length=1, max_length=64)
+
+
+class LocationUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=255)
+    address: str | None = Field(None, max_length=500)
+    timezone: str | None = Field(None, min_length=1, max_length=64)
+
+
+class LocationOut(BaseModel):
+    id: int
+    organization_id: int
+    name: str
+    address: str | None
+    timezone: str
+    is_default: bool
+    feedback_token: str
+    review_links: list[ReviewLink] | None = None
+    access_role: str
+    can_manage: bool
+    created_at: datetime
+
+
+class LocationReviewLinksUpdate(BaseModel):
+    review_links: list[ReviewLink]
+
+
+class LocationAssignment(BaseModel):
+    location_id: int
+    role: Literal["manager", "viewer"] = "viewer"
+
+
+class MemberLocationAssignmentsUpdate(BaseModel):
+    assignments: list[LocationAssignment]
 
 
 # Member schemas
@@ -76,17 +121,29 @@ class MemberOut(BaseModel):
     email: str
     role: str
     joined_at: datetime
+    location_assignments: list[LocationAssignment] = Field(default_factory=list)
 
 
 class MemberUpdateRole(BaseModel):
-    role: str = Field(pattern="^(admin|viewer)$")
+    role: Literal[
+        "organization_admin",
+        "organization_viewer",
+        "location_admin",
+        "location_viewer",
+    ]
 
 
 # Invite schemas
 
 
 class InviteCreate(BaseModel):
-    role: str = Field(pattern="^(admin|viewer)$")
+    role: Literal[
+        "organization_admin",
+        "organization_viewer",
+        "location_admin",
+        "location_viewer",
+    ]
+    location_id: int | None = None
     expires_in_hours: int = Field(default=168, ge=1, le=720)
 
 
@@ -98,12 +155,17 @@ class InviteOut(BaseModel):
     expires_at: datetime
     used_at: datetime | None
     invite_url: str
+    location_id: int | None = None
+    location_name: str | None = None
+    location_role: str | None = None
 
 
 class InviteInfo(BaseModel):
     organization_name: str
     role: str
     expires_at: datetime
+    location_name: str | None = None
+    location_role: str | None = None
 
 
 class InviteAccept(BaseModel):
@@ -122,6 +184,7 @@ class FeedbackSubmit(BaseModel):
 class FeedbackOut(BaseModel):
     id: int
     organization_id: int
+    location_id: int
     content: str
     submitter_email: str | None
     submitter_name: str | None
@@ -132,12 +195,58 @@ class FeedbackOut(BaseModel):
 class FeedbackFormInfo(BaseModel):
     organization_name: str
     organization_id: int
+    location_name: str
+    location_id: int
     review_links: list[ReviewLink] | None = None
 
 
 class FeedbackSubmitResponse(BaseModel):
     success: bool
     message: str
+
+
+class InitiativeCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=160)
+    description: str = Field(min_length=1, max_length=5000)
+    status: Literal["gathering_feedback", "planned", "in_progress", "shipped"] = "gathering_feedback"
+    location_id: int | None = None
+
+
+class InitiativeUpdate(BaseModel):
+    title: str | None = Field(None, min_length=1, max_length=160)
+    description: str | None = Field(None, min_length=1, max_length=5000)
+    status: Literal["gathering_feedback", "planned", "in_progress", "shipped"] | None = None
+
+
+class InitiativeOut(BaseModel):
+    id: int
+    organization_id: int
+    location_id: int
+    location_name: str
+    title: str
+    description: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    upvotes: int
+    downvotes: int
+    score: int
+
+
+class PublicInitiativeOut(InitiativeOut):
+    viewer_vote: Literal[-1, 1] | None = None
+
+
+class BoardOut(BaseModel):
+    organization_name: str
+    organization_id: int
+    location_name: str
+    location_id: int
+    initiatives: list[PublicInitiativeOut]
+
+
+class InitiativeVoteUpdate(BaseModel):
+    value: Literal[-1, 1] | None = None
 
 
 class ReviewPolishRequest(BaseModel):
@@ -147,6 +256,101 @@ class ReviewPolishRequest(BaseModel):
 
 class ReviewPolishResponse(BaseModel):
     draft: str
+
+
+# Social connection schemas
+
+
+class SocialConnectionOut(BaseModel):
+    provider: Literal["facebook", "instagram", "tiktok"]
+    name: str
+    description: str
+    configured: bool
+    connected: bool
+    publishing_enabled: bool
+    status: str
+    provider_account_id: str | None = None
+    provider_account_name: str | None = None
+    scopes: list[str] = Field(default_factory=list)
+    expires_at: datetime | None = None
+    connected_at: datetime | None = None
+    connection_method: str | None = None
+    linked_page_name: str | None = None
+    diagnostic: str | None = None
+
+
+class SocialAuthorizationOut(BaseModel):
+    authorization_url: str
+
+
+class MetaInstagramAccountOut(BaseModel):
+    id: str
+    username: str | None = None
+    name: str | None = None
+    profile_picture_url: str | None = None
+
+
+class MetaPageOptionOut(BaseModel):
+    id: str
+    name: str
+    tasks: list[str] = Field(default_factory=list)
+    instagram: MetaInstagramAccountOut | None = None
+
+
+class MetaConnectionOptionsOut(BaseModel):
+    pages: list[MetaPageOptionOut]
+
+
+class MetaConnectionComplete(BaseModel):
+    setup_token: str = Field(min_length=20, max_length=200)
+    page_id: str = Field(min_length=1, max_length=255)
+
+
+class SocialPostTargetCreate(BaseModel):
+    provider: Literal["facebook", "instagram", "tiktok"]
+    content: str = Field(min_length=1, max_length=10000)
+
+
+class SocialDraftGenerate(BaseModel):
+    master_caption: str = Field(min_length=1, max_length=10000)
+
+
+class SocialDraftContent(BaseModel):
+    facebook: str = Field(min_length=1, max_length=10000)
+    instagram: str = Field(min_length=1, max_length=10000)
+    tiktok: str = Field(min_length=1, max_length=10000)
+
+
+class SocialPostCreate(BaseModel):
+    master_caption: str = Field(min_length=1, max_length=10000)
+    targets: list[SocialPostTargetCreate] = Field(min_length=1, max_length=4)
+    media_urls: list[str] = Field(default_factory=list, max_length=10)
+    scheduled_at: datetime | None = None
+
+
+class SocialPostTargetOut(BaseModel):
+    id: int
+    # Old saved posts can retain a now-hidden provider; keep their history readable.
+    provider: str
+    content: str
+    status: str
+    remote_post_id: str | None = None
+    error: str | None = None
+    published_at: datetime | None = None
+
+
+class SocialPostOut(BaseModel):
+    id: int
+    organization_id: int
+    master_caption: str
+    media_urls: list[str] = Field(default_factory=list)
+    status: str
+    scheduled_at: datetime | None = None
+    published_at: datetime | None = None
+    created_by: int
+    created_at: datetime
+    updated_at: datetime
+    targets: list[SocialPostTargetOut] = Field(default_factory=list)
 
 
 # Organization Search
@@ -175,6 +379,7 @@ class FeedbackStatsOut(BaseModel):
 class DigestGenerate(BaseModel):
     period_start: Date
     period_end: Date
+    location_id: int | None = None
 
 
 class DigestContent(BaseModel):
@@ -195,6 +400,8 @@ class DigestUpdate(BaseModel):
 class DigestOut(BaseModel):
     id: int
     organization_id: int
+    location_id: int
+    location_name: str
     status: str
     period_start: Date
     period_end: Date

--- a/backend/app/social.py
+++ b/backend/app/social.py
@@ -1,0 +1,469 @@
+import base64
+import hashlib
+import secrets
+from datetime import datetime, timedelta
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+
+from .config import Settings, get_settings
+
+
+SUPPORTED_PROVIDERS = ("facebook", "instagram", "tiktok")
+
+PROVIDER_DETAILS = {
+    "facebook": {
+        "name": "Facebook",
+        "description": "Pages and business profiles",
+        "publishing_enabled": True,
+        "scopes": [
+            "pages_show_list",
+            "pages_read_engagement",
+            "pages_manage_posts",
+            "instagram_basic",
+            "instagram_content_publish",
+        ],
+    },
+    "instagram": {
+        "name": "Instagram",
+        "description": "Professional accounts",
+        "publishing_enabled": True,
+        "scopes": [
+            "instagram_business_basic",
+            "instagram_business_content_publish",
+        ],
+    },
+    "tiktok": {
+        "name": "TikTok",
+        "description": "Business and creator accounts",
+        "publishing_enabled": False,
+        "scopes": ["user.info.basic", "video.publish"],
+    },
+}
+
+
+class SocialProviderError(RuntimeError):
+    pass
+
+
+def validate_provider(provider: str) -> str:
+    provider = provider.lower()
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError("Unsupported social provider")
+    return provider
+
+
+def provider_configured(provider: str, settings: Settings | None = None) -> bool:
+    settings = settings or get_settings()
+    provider = validate_provider(provider)
+    if provider == "facebook":
+        return bool(settings.meta_client_id and settings.meta_client_secret)
+    if provider == "instagram":
+        return bool(settings.instagram_client_id and settings.instagram_client_secret)
+    if provider == "tiktok":
+        return bool(settings.tiktok_client_key and settings.tiktok_client_secret)
+    raise ValueError("Unsupported social provider")
+
+
+def callback_url(provider: str, settings: Settings | None = None) -> str:
+    settings = settings or get_settings()
+    return f"{settings.api_base_url.rstrip('/')}/oauth/social/{provider}/callback"
+
+
+def generate_oauth_state() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def hash_oauth_state(raw_state: str) -> str:
+    return hashlib.sha256(raw_state.encode("utf-8")).hexdigest()
+
+
+def build_authorization_url(
+    provider: str,
+    state: str,
+    settings: Settings | None = None,
+) -> str:
+    settings = settings or get_settings()
+    provider = validate_provider(provider)
+    redirect_uri = callback_url(provider, settings)
+    scopes = PROVIDER_DETAILS[provider]["scopes"]
+
+    if provider == "facebook":
+        query = urlencode(
+            {
+                "client_id": settings.meta_client_id,
+                "redirect_uri": redirect_uri,
+                "response_type": "code",
+                "scope": ",".join(scopes),
+                "state": state,
+            }
+        )
+        return f"https://www.facebook.com/dialog/oauth?{query}"
+
+    if provider == "instagram":
+        query = urlencode(
+            {
+                "force_reauth": "true",
+                "client_id": settings.instagram_client_id,
+                "redirect_uri": redirect_uri,
+                "response_type": "code",
+                "scope": ",".join(scopes),
+                "state": state,
+            }
+        )
+        return f"https://www.instagram.com/oauth/authorize?{query}"
+
+    if provider == "tiktok":
+        query = urlencode(
+            {
+                "client_key": settings.tiktok_client_key,
+                "redirect_uri": redirect_uri,
+                "response_type": "code",
+                "scope": ",".join(scopes),
+                "state": state,
+            }
+        )
+        return f"https://www.tiktok.com/v2/auth/authorize/?{query}"
+
+    raise ValueError("Unsupported social provider")
+
+
+def _response_json(response: httpx.Response, provider: str) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise SocialProviderError(f"{provider.title()} returned an invalid response") from exc
+    if response.is_error:
+        error = payload.get("error")
+        error_detail = error.get("message") if isinstance(error, dict) else error
+        detail = payload.get("error_description") or payload.get("message") or error_detail
+        raise SocialProviderError(
+            str(detail) if detail else f"{provider.title()} rejected the connection"
+        )
+    return payload
+
+
+def exchange_social_code(
+    provider: str,
+    code: str,
+    settings: Settings | None = None,
+) -> dict[str, Any]:
+    settings = settings or get_settings()
+    provider = validate_provider(provider)
+    redirect_uri = callback_url(provider, settings)
+
+    with httpx.Client(timeout=20.0) as client:
+        if provider == "facebook":
+            response = client.get(
+                "https://graph.facebook.com/oauth/access_token",
+                params={
+                    "client_id": settings.meta_client_id,
+                    "client_secret": settings.meta_client_secret,
+                    "redirect_uri": redirect_uri,
+                    "code": code,
+                },
+            )
+        elif provider == "instagram":
+            response = client.post(
+                "https://api.instagram.com/oauth/access_token",
+                data={
+                    "client_id": settings.instagram_client_id,
+                    "client_secret": settings.instagram_client_secret,
+                    "grant_type": "authorization_code",
+                    "redirect_uri": redirect_uri,
+                    "code": code,
+                },
+            )
+            short_lived = _response_json(response, provider)
+            short_lived_token = short_lived.get("access_token")
+            if not short_lived_token:
+                raise SocialProviderError("Instagram did not return an access token")
+            response = client.get(
+                "https://graph.instagram.com/access_token",
+                params={
+                    "grant_type": "ig_exchange_token",
+                    "client_secret": settings.instagram_client_secret,
+                    "access_token": short_lived_token,
+                },
+            )
+            return {**short_lived, **_response_json(response, provider)}
+        elif provider == "tiktok":
+            response = client.post(
+                "https://open.tiktokapis.com/v2/oauth/token/",
+                data={
+                    "client_key": settings.tiktok_client_key,
+                    "client_secret": settings.tiktok_client_secret,
+                    "code": code,
+                    "grant_type": "authorization_code",
+                    "redirect_uri": redirect_uri,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        else:
+            raise ValueError("Unsupported social provider")
+    return _response_json(response, provider)
+
+
+def fetch_social_identity(provider: str, token_data: dict[str, Any]) -> dict[str, Any]:
+    provider = validate_provider(provider)
+    access_token = token_data.get("access_token")
+    if not access_token:
+        raise SocialProviderError(f"{provider.title()} did not return an access token")
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    with httpx.Client(timeout=20.0) as client:
+        if provider == "facebook":
+            pages = fetch_facebook_pages(access_token, client=client)
+            if not pages:
+                raise SocialProviderError(
+                    "No Facebook Pages are available for this account"
+                )
+            identity = pages[0]
+            return {
+                "id": str(identity.get("id", "")),
+                "name": identity.get("name") or "Facebook Page",
+                "data": {
+                    "auth_type": "facebook_login",
+                    "page_id": str(identity.get("id", "")),
+                    "tasks": identity.get("tasks") or [],
+                    "instagram": identity.get("instagram"),
+                },
+            }
+        if provider == "instagram":
+            response = client.get(
+                "https://graph.instagram.com/me",
+                params={
+                    "fields": "user_id,username,name,account_type,profile_picture_url",
+                    "access_token": access_token,
+                },
+            )
+            identity = _response_json(response, provider)
+            username = identity.get("username")
+            return {
+                "id": str(identity.get("user_id") or identity.get("id") or ""),
+                "name": username or identity.get("name") or "Instagram account",
+                "data": {
+                    "username": username,
+                    "account_type": identity.get("account_type"),
+                    "profile_picture_url": identity.get("profile_picture_url"),
+                },
+            }
+        if provider == "tiktok":
+            response = client.get(
+                "https://open.tiktokapis.com/v2/user/info/",
+                params={"fields": "open_id,display_name,avatar_url"},
+                headers=headers,
+            )
+            payload = _response_json(response, provider)
+            identity = payload.get("data", {}).get("user", {})
+            return {
+                "id": str(identity.get("open_id") or token_data.get("open_id", "")),
+                "name": identity.get("display_name") or "TikTok account",
+                "data": {"avatar_url": identity.get("avatar_url")},
+            }
+
+        raise ValueError("Unsupported social provider")
+
+
+def fetch_facebook_pages(
+    access_token: str,
+    *,
+    client: httpx.Client | None = None,
+) -> list[dict[str, Any]]:
+    """Return Pages available to the user, including linked Instagram accounts.
+
+    Page access tokens are intentionally returned only to server-side callers and
+    must never be serialized into API responses or provider_data.
+    """
+
+    owns_client = client is None
+    graph_client = client or httpx.Client(timeout=20.0)
+    try:
+        response = graph_client.get(
+            "https://graph.facebook.com/me/accounts",
+            params={
+                "fields": (
+                    "id,name,access_token,tasks,"
+                    "instagram_business_account"
+                    "{id,username,name,profile_picture_url}"
+                ),
+                "access_token": access_token,
+            },
+        )
+        payload = _response_json(response, "facebook")
+    finally:
+        if owns_client:
+            graph_client.close()
+
+    pages: list[dict[str, Any]] = []
+    for raw_page in payload.get("data") or []:
+        page_id = raw_page.get("id")
+        page_token = raw_page.get("access_token")
+        if not page_id or not page_token:
+            continue
+        raw_instagram = raw_page.get("instagram_business_account")
+        instagram = None
+        if isinstance(raw_instagram, dict) and raw_instagram.get("id"):
+            instagram = {
+                "id": str(raw_instagram["id"]),
+                "username": raw_instagram.get("username"),
+                "name": raw_instagram.get("name"),
+                "profile_picture_url": raw_instagram.get("profile_picture_url"),
+            }
+        pages.append(
+            {
+                "id": str(page_id),
+                "name": raw_page.get("name") or "Facebook Page",
+                "access_token": str(page_token),
+                "tasks": [str(task) for task in (raw_page.get("tasks") or [])],
+                "instagram": instagram,
+            }
+        )
+    return pages
+
+
+def publish_social_content(
+    provider: str,
+    *,
+    account_id: str,
+    access_token: str,
+    content: str,
+    media_urls: list[str] | None = None,
+    provider_data: dict[str, Any] | None = None,
+) -> str:
+    """Publish one target and return the provider's post identifier.
+
+    Facebook supports text-only posts and a single remotely hosted image in V1.
+    Instagram requires one publicly reachable image URL.
+    """
+
+    provider = validate_provider(provider)
+    media_urls = media_urls or []
+    provider_data = provider_data or {}
+
+    with httpx.Client(timeout=30.0) as client:
+        if provider == "facebook":
+            if media_urls:
+                response = client.post(
+                    f"https://graph.facebook.com/{account_id}/photos",
+                    data={
+                        "url": media_urls[0],
+                        "caption": content,
+                        "access_token": access_token,
+                    },
+                )
+            else:
+                response = client.post(
+                    f"https://graph.facebook.com/{account_id}/feed",
+                    data={"message": content, "access_token": access_token},
+                )
+            payload = _response_json(response, provider)
+            remote_id = payload.get("post_id") or payload.get("id")
+        elif provider == "instagram":
+            if not media_urls:
+                raise SocialProviderError(
+                    "Instagram requires a publicly reachable image before publishing"
+                )
+            graph_host = (
+                "graph.facebook.com"
+                if provider_data.get("auth_type") == "facebook_login"
+                else "graph.instagram.com"
+            )
+            container_response = client.post(
+                f"https://{graph_host}/{account_id}/media",
+                data={
+                    "image_url": media_urls[0],
+                    "caption": content,
+                    "access_token": access_token,
+                },
+            )
+            container = _response_json(container_response, provider)
+            creation_id = container.get("id")
+            if not creation_id:
+                raise SocialProviderError(
+                    "Instagram did not return a media container"
+                )
+            publish_response = client.post(
+                f"https://{graph_host}/{account_id}/media_publish",
+                data={
+                    "creation_id": creation_id,
+                    "access_token": access_token,
+                },
+            )
+            payload = _response_json(publish_response, provider)
+            remote_id = payload.get("id")
+        else:
+            raise SocialProviderError(
+                f"{PROVIDER_DETAILS[provider]['name']} publishing is not enabled yet"
+            )
+
+    if not remote_id:
+        raise SocialProviderError(
+            f"{PROVIDER_DETAILS[provider]['name']} did not return a post identifier"
+        )
+    return str(remote_id)
+
+
+def requested_scopes(provider: str, token_data: dict[str, Any]) -> list[str]:
+    raw_scopes = token_data.get("scope")
+    if isinstance(raw_scopes, str):
+        normalized = raw_scopes.replace(",", " ").split()
+        return list(dict.fromkeys(normalized))
+    if isinstance(raw_scopes, list):
+        return [str(scope) for scope in raw_scopes]
+    return list(PROVIDER_DETAILS[provider]["scopes"])
+
+
+def token_expiry(token_data: dict[str, Any]) -> datetime | None:
+    raw_seconds = token_data.get("expires_in")
+    if raw_seconds is None:
+        return None
+    try:
+        return datetime.utcnow() + timedelta(seconds=max(0, int(raw_seconds)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _fernet(settings: Settings | None = None) -> Fernet:
+    settings = settings or get_settings()
+    secret = settings.oauth_token_encryption_key or settings.jwt_secret_key
+    key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
+    return Fernet(key)
+
+
+def encrypt_token(token: str, settings: Settings | None = None) -> str:
+    return _fernet(settings).encrypt(token.encode("utf-8")).decode("ascii")
+
+
+def decrypt_token(token: str, settings: Settings | None = None) -> str:
+    try:
+        return _fernet(settings).decrypt(token.encode("ascii")).decode("utf-8")
+    except InvalidToken as exc:
+        raise SocialProviderError("Stored social credentials could not be decrypted") from exc
+
+
+def revoke_social_token(
+    provider: str,
+    encrypted_access_token: str,
+    settings: Settings | None = None,
+) -> None:
+    provider = validate_provider(provider)
+    access_token = decrypt_token(encrypted_access_token, settings)
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            if provider == "facebook":
+                client.delete(
+                    "https://graph.facebook.com/me/permissions",
+                    params={"access_token": access_token},
+                )
+            elif provider == "tiktok":
+                client.post(
+                    "https://open.tiktokapis.com/v2/oauth/revoke/",
+                    data={"token": access_token},
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
+    except httpx.HTTPError:
+        # Local disconnect must still succeed if the provider is unavailable.
+        return

--- a/backend/migrations/versions/0005_add_initiatives_and_votes.py
+++ b/backend/migrations/versions/0005_add_initiatives_and_votes.py
@@ -1,0 +1,58 @@
+"""Add organization initiatives and anonymous votes
+
+Revision ID: 0005
+Revises: 0004
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0005"
+down_revision = "0004"
+
+
+def upgrade():
+    initiative_status = postgresql.ENUM(
+        "gathering_feedback",
+        "planned",
+        "in_progress",
+        "shipped",
+        name="initiative_status",
+        create_type=False,
+    )
+    initiative_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "initiatives",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("title", sa.String(160), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("status", initiative_status, nullable=False, server_default="gathering_feedback"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_initiatives_id", "initiatives", ["id"])
+    op.create_index("ix_initiatives_organization_id", "initiatives", ["organization_id"])
+
+    op.create_table(
+        "initiative_votes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("initiative_id", sa.Integer(), sa.ForeignKey("initiatives.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("visitor_id", sa.String(64), nullable=False),
+        sa.Column("value", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("value IN (-1, 1)", name="ck_initiative_vote_value"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("initiative_id", "visitor_id", name="uq_initiative_vote_visitor"),
+    )
+    op.create_index("ix_initiative_votes_id", "initiative_votes", ["id"])
+    op.create_index("ix_initiative_votes_initiative_id", "initiative_votes", ["initiative_id"])
+
+
+def downgrade():
+    op.drop_table("initiative_votes")
+    op.drop_table("initiatives")
+    sa.Enum(name="initiative_status").drop(op.get_bind(), checkfirst=True)

--- a/backend/migrations/versions/0006_add_locations.py
+++ b/backend/migrations/versions/0006_add_locations.py
@@ -1,0 +1,188 @@
+"""Add location tenancy and scoped member access.
+
+Revision ID: 0006
+Revises: 0005
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0006"
+down_revision = "0005"
+
+
+def upgrade() -> None:
+    location_role = postgresql.ENUM(
+        "manager",
+        "viewer",
+        name="location_role",
+        create_type=False,
+    )
+    location_role.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "locations",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("address", sa.String(500), nullable=True),
+        sa.Column("timezone", sa.String(64), nullable=False, server_default="America/Chicago"),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("feedback_token", sa.String(64), nullable=False),
+        sa.Column("review_links", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("created_by", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("feedback_token"),
+        sa.UniqueConstraint("id", "organization_id", name="uq_location_id_organization"),
+    )
+    op.create_index("ix_locations_id", "locations", ["id"])
+    op.create_index("ix_locations_organization_id", "locations", ["organization_id"])
+    op.create_index("ix_locations_feedback_token", "locations", ["feedback_token"], unique=True)
+    op.create_index(
+        "uq_locations_default_per_org",
+        "locations",
+        ["organization_id"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+
+    op.execute(
+        """
+        INSERT INTO locations (
+            organization_id,
+            name,
+            address,
+            timezone,
+            is_default,
+            feedback_token,
+            review_links,
+            created_at,
+            created_by
+        )
+        SELECT
+            id,
+            name,
+            NULL,
+            'America/Chicago',
+            TRUE,
+            feedback_token,
+            review_links,
+            created_at,
+            created_by
+        FROM organizations
+        """
+    )
+
+    op.create_table(
+        "location_memberships",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("location_id", sa.Integer(), nullable=False),
+        sa.Column("role", location_role, nullable=False, server_default="viewer"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(
+            ["user_id", "organization_id"],
+            ["organization_members.user_id", "organization_members.organization_id"],
+            ondelete="CASCADE",
+            name="fk_location_membership_organization_member",
+        ),
+        sa.ForeignKeyConstraint(
+            ["location_id", "organization_id"],
+            ["locations.id", "locations.organization_id"],
+            ondelete="CASCADE",
+            name="fk_location_membership_location",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "location_id", name="uq_user_location"),
+    )
+    op.create_index("ix_location_memberships_id", "location_memberships", ["id"])
+    op.create_index("ix_location_memberships_location_id", "location_memberships", ["location_id"])
+
+    op.execute(
+        """
+        INSERT INTO location_memberships (
+            user_id,
+            organization_id,
+            location_id,
+            role,
+            created_at
+        )
+        SELECT
+            member.user_id,
+            member.organization_id,
+            location.id,
+            'viewer',
+            member.joined_at
+        FROM organization_members AS member
+        JOIN locations AS location
+          ON location.organization_id = member.organization_id
+         AND location.is_default = TRUE
+        WHERE lower(member.role::text) = 'viewer'
+        """
+    )
+
+    for table_name in ("feedback", "initiatives", "digests"):
+        op.add_column(table_name, sa.Column("location_id", sa.Integer(), nullable=True))
+        op.execute(
+            f"""
+            UPDATE {table_name} AS item
+            SET location_id = location.id
+            FROM locations AS location
+            WHERE location.organization_id = item.organization_id
+              AND location.is_default = TRUE
+            """
+        )
+        op.alter_column(table_name, "location_id", nullable=False)
+        op.create_foreign_key(
+            f"fk_{table_name}_location",
+            table_name,
+            "locations",
+            ["location_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+        op.create_index(f"ix_{table_name}_location_id", table_name, ["location_id"])
+
+    op.add_column("invites", sa.Column("location_id", sa.Integer(), nullable=True))
+    op.add_column("invites", sa.Column("location_role", location_role, nullable=True))
+    op.create_foreign_key(
+        "fk_invites_location",
+        "invites",
+        "locations",
+        ["location_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.execute(
+        """
+        UPDATE invites AS invite
+        SET
+            location_id = location.id,
+            location_role = 'viewer'
+        FROM locations AS location
+        WHERE location.organization_id = invite.organization_id
+          AND location.is_default = TRUE
+          AND lower(invite.role::text) = 'viewer'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_invites_location", "invites", type_="foreignkey")
+    op.drop_column("invites", "location_role")
+    op.drop_column("invites", "location_id")
+
+    for table_name in ("digests", "initiatives", "feedback"):
+        op.drop_index(f"ix_{table_name}_location_id", table_name=table_name)
+        op.drop_constraint(f"fk_{table_name}_location", table_name, type_="foreignkey")
+        op.drop_column(table_name, "location_id")
+
+    op.drop_table("location_memberships")
+    op.drop_index("uq_locations_default_per_org", table_name="locations")
+    op.drop_table("locations")
+    sa.Enum(name="location_role").drop(op.get_bind(), checkfirst=True)

--- a/backend/migrations/versions/0007_add_explicit_access_roles.py
+++ b/backend/migrations/versions/0007_add_explicit_access_roles.py
@@ -1,0 +1,77 @@
+"""Add explicit organization and location access levels.
+
+Revision ID: 0007
+Revises: 0006
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0007"
+down_revision = "0006"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    # Older local databases were initialized from SQLAlchemy metadata, which
+    # used uppercase enum labels. Normalize those values before adding the new
+    # lower-case label used by the migrations and application model.
+    labels = set(
+        bind.execute(
+            sa.text(
+                """
+                SELECT enumlabel
+                FROM pg_enum
+                WHERE enumtypid = 'role'::regtype
+                """
+            )
+        ).scalars()
+    )
+    # PostgreSQL requires an enum value to be committed before it can be used
+    # by the data migration below, so these type changes need their own block.
+    with op.get_context().autocommit_block():
+        for legacy, normalized in (("ADMIN", "admin"), ("VIEWER", "viewer"), ("LOCATION", "location")):
+            if legacy in labels and normalized not in labels:
+                op.execute(f"ALTER TYPE role RENAME VALUE '{legacy}' TO '{normalized}'")
+                labels.remove(legacy)
+                labels.add(normalized)
+        op.execute("ALTER TYPE role ADD VALUE IF NOT EXISTS 'location'")
+
+    # Before this migration, every viewer was location-scoped when a location
+    # assignment existed. Preserve that behavior while reserving `viewer` for
+    # the new organization-wide read-only role.
+    op.execute(
+        """
+        UPDATE organization_members AS member
+        SET role = 'location'
+        WHERE role = 'viewer'
+          AND EXISTS (
+              SELECT 1
+              FROM location_memberships AS assignment
+              WHERE assignment.user_id = member.user_id
+                AND assignment.organization_id = member.organization_id
+          )
+        """
+    )
+    op.execute(
+        """
+        UPDATE invites
+        SET role = 'location'
+        WHERE role = 'viewer'
+          AND location_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    # PostgreSQL enum values cannot be safely removed in place. Downgrades keep
+    # the value but map location-scoped rows back to the legacy viewer role.
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("UPDATE organization_members SET role = 'viewer' WHERE role = 'location'")
+    op.execute("UPDATE invites SET role = 'viewer' WHERE role = 'location'")

--- a/backend/migrations/versions/0008_add_social_connections.py
+++ b/backend/migrations/versions/0008_add_social_connections.py
@@ -1,0 +1,83 @@
+"""Add organization social connections and OAuth state.
+
+Revision ID: 0008
+Revises: 0007
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0008"
+down_revision = "0007"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "social_connections",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(32), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False, server_default="connected"),
+        sa.Column("provider_account_id", sa.String(255), nullable=True),
+        sa.Column("provider_account_name", sa.String(255), nullable=True),
+        sa.Column("access_token_encrypted", sa.Text(), nullable=False),
+        sa.Column("refresh_token_encrypted", sa.Text(), nullable=True),
+        sa.Column("scopes", sa.JSON(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column("provider_data", sa.JSON(), nullable=True),
+        sa.Column("connected_by", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["connected_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "organization_id",
+            "provider",
+            name="uq_social_connection_org_provider",
+        ),
+    )
+    op.create_index("ix_social_connections_id", "social_connections", ["id"])
+    op.create_index(
+        "ix_social_connections_organization_id",
+        "social_connections",
+        ["organization_id"],
+    )
+
+    op.create_table(
+        "social_oauth_states",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("state_hash", sa.String(64), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(32), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_social_oauth_states_id", "social_oauth_states", ["id"])
+    op.create_index(
+        "ix_social_oauth_states_organization_id",
+        "social_oauth_states",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_social_oauth_states_state_hash",
+        "social_oauth_states",
+        ["state_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_social_oauth_states_state_hash", table_name="social_oauth_states")
+    op.drop_index("ix_social_oauth_states_organization_id", table_name="social_oauth_states")
+    op.drop_index("ix_social_oauth_states_id", table_name="social_oauth_states")
+    op.drop_table("social_oauth_states")
+    op.drop_index("ix_social_connections_organization_id", table_name="social_connections")
+    op.drop_index("ix_social_connections_id", table_name="social_connections")
+    op.drop_table("social_connections")

--- a/backend/migrations/versions/0009_add_social_post_pipeline.py
+++ b/backend/migrations/versions/0009_add_social_post_pipeline.py
@@ -1,0 +1,141 @@
+"""Add Meta connection setup and persisted social posts.
+
+Revision ID: 0009
+Revises: 0008
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0009"
+down_revision = "0008"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "social_connection_setups",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(64), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(32), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("access_token_encrypted", sa.Text(), nullable=False),
+        sa.Column("scopes", sa.JSON(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_social_connection_setups_id",
+        "social_connection_setups",
+        ["id"],
+    )
+    op.create_index(
+        "ix_social_connection_setups_organization_id",
+        "social_connection_setups",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_social_connection_setups_token_hash",
+        "social_connection_setups",
+        ["token_hash"],
+        unique=True,
+    )
+
+    op.create_table(
+        "social_posts",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("master_caption", sa.Text(), nullable=False),
+        sa.Column("media_urls", sa.JSON(), nullable=True),
+        sa.Column("status", sa.String(32), nullable=False, server_default="draft"),
+        sa.Column("scheduled_at", sa.DateTime(), nullable=True),
+        sa.Column("published_at", sa.DateTime(), nullable=True),
+        sa.Column("created_by", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_social_posts_id", "social_posts", ["id"])
+    op.create_index(
+        "ix_social_posts_organization_id",
+        "social_posts",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_social_posts_scheduled_at",
+        "social_posts",
+        ["scheduled_at"],
+    )
+
+    op.create_table(
+        "social_post_targets",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("post_id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(32), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False, server_default="pending"),
+        sa.Column("remote_post_id", sa.String(255), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("published_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["post_id"],
+            ["social_posts.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "post_id",
+            "provider",
+            name="uq_social_post_target_provider",
+        ),
+    )
+    op.create_index(
+        "ix_social_post_targets_id",
+        "social_post_targets",
+        ["id"],
+    )
+    op.create_index(
+        "ix_social_post_targets_post_id",
+        "social_post_targets",
+        ["post_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_social_post_targets_post_id", table_name="social_post_targets")
+    op.drop_index("ix_social_post_targets_id", table_name="social_post_targets")
+    op.drop_table("social_post_targets")
+    op.drop_index("ix_social_posts_scheduled_at", table_name="social_posts")
+    op.drop_index("ix_social_posts_organization_id", table_name="social_posts")
+    op.drop_index("ix_social_posts_id", table_name="social_posts")
+    op.drop_table("social_posts")
+    op.drop_index(
+        "ix_social_connection_setups_token_hash",
+        table_name="social_connection_setups",
+    )
+    op.drop_index(
+        "ix_social_connection_setups_organization_id",
+        table_name="social_connection_setups",
+    )
+    op.drop_index(
+        "ix_social_connection_setups_id",
+        table_name="social_connection_setups",
+    )
+    op.drop_table("social_connection_setups")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ alembic==1.14.0
 sendgrid==6.11.0
 slowapi==0.1.9
 sentry-sdk[fastapi]==2.20.0
+httpx==0.28.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 os.environ["RATE_LIMIT_ENABLED"] = "false"
 os.environ["JWT_SECRET_KEY"] = "test-secret"
 os.environ["SENTRY_DSN"] = ""
+os.environ["SOCIAL_SCHEDULER_ENABLED"] = "false"
 
 import pytest
 from fastapi.testclient import TestClient

--- a/backend/tests/test_initiatives.py
+++ b/backend/tests/test_initiatives.py
@@ -1,0 +1,135 @@
+def create_org(client, headers, name="Acme Diner"):
+    response = client.post("/organizations", json={"name": name}, headers=headers)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def create_initiative(client, headers, org_id, title, description="Details", status="gathering_feedback"):
+    response = client.post(
+        f"/organizations/{org_id}/initiatives",
+        json={"title": title, "description": description, "status": status},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_initiative_admin_crud_and_viewer_read_access(client, auth_headers):
+    owner_headers = auth_headers("owner@example.com")
+    org = create_org(client, owner_headers)
+    initiative = create_initiative(client, owner_headers, org["id"], "Online booking")
+
+    assert initiative["status"] == "gathering_feedback"
+    assert initiative["score"] == 0
+
+    updated = client.patch(
+        f"/organizations/{org['id']}/initiatives/{initiative['id']}",
+        json={"title": "Online booking for groups", "status": "planned"},
+        headers=owner_headers,
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["title"] == "Online booking for groups"
+    assert updated.json()["status"] == "planned"
+
+    viewer_headers = auth_headers("viewer@example.com")
+    invite = client.post(
+        f"/organizations/{org['id']}/invites",
+        json={"role": "organization_viewer"},
+        headers=owner_headers,
+    )
+    assert invite.status_code == 201, invite.text
+    accepted = client.post("/invites/accept", json={"token": invite.json()["token"]}, headers=viewer_headers)
+    assert accepted.status_code == 200, accepted.text
+
+    listed = client.get(f"/organizations/{org['id']}/initiatives", headers=viewer_headers)
+    assert listed.status_code == 200
+    assert listed.json()[0]["id"] == initiative["id"]
+
+    forbidden = client.post(
+        f"/organizations/{org['id']}/initiatives",
+        json={"title": "Not allowed", "description": "A viewer cannot post this."},
+        headers=viewer_headers,
+    )
+    assert forbidden.status_code == 403
+
+    deleted = client.delete(
+        f"/organizations/{org['id']}/initiatives/{initiative['id']}",
+        headers=owner_headers,
+    )
+    assert deleted.status_code == 204
+    assert client.get(f"/organizations/{org['id']}/initiatives", headers=owner_headers).json() == []
+
+
+def test_public_board_filters_sorts_and_tracks_one_anonymous_vote(client, auth_headers):
+    owner_headers = auth_headers()
+    org = create_org(client, owner_headers)
+    low_priority = create_initiative(client, owner_headers, org["id"], "New loyalty card", status="planned")
+    high_priority = create_initiative(client, owner_headers, org["id"], "Online booking", status="in_progress")
+    board_url = f"/api/boards/{org['feedback_token']}"
+    voter_one = {"X-Visitor-ID": "7a8d7f1b-e1dd-48f6-9dcb-1f773c2d957e"}
+    voter_two = {"X-Visitor-ID": "75e6d350-10a5-4dbe-bd9a-1e87d7dd8f38"}
+
+    first_vote = client.put(
+        f"{board_url}/initiatives/{high_priority['id']}/vote",
+        json={"value": 1},
+        headers=voter_one,
+    )
+    assert first_vote.status_code == 200, first_vote.text
+    assert first_vote.json()["upvotes"] == 1
+    assert first_vote.json()["viewer_vote"] == 1
+
+    repeated_vote = client.put(
+        f"{board_url}/initiatives/{high_priority['id']}/vote",
+        json={"value": 1},
+        headers=voter_one,
+    )
+    assert repeated_vote.status_code == 200
+    assert repeated_vote.json()["upvotes"] == 1
+
+    changed_vote = client.put(
+        f"{board_url}/initiatives/{high_priority['id']}/vote",
+        json={"value": -1},
+        headers=voter_one,
+    )
+    assert changed_vote.status_code == 200
+    assert changed_vote.json()["upvotes"] == 0
+    assert changed_vote.json()["downvotes"] == 1
+    assert changed_vote.json()["viewer_vote"] == -1
+
+    client.put(
+        f"{board_url}/initiatives/{high_priority['id']}/vote",
+        json={"value": 1},
+        headers=voter_two,
+    )
+    top_board = client.get(board_url, headers=voter_one)
+    assert top_board.status_code == 200, top_board.text
+    assert top_board.json()["organization_name"] == "Acme Diner"
+    assert top_board.json()["initiatives"][0]["id"] == high_priority["id"]
+    assert top_board.json()["initiatives"][0]["score"] == 0
+    assert top_board.json()["initiatives"][0]["viewer_vote"] == -1
+
+    filtered = client.get(f"{board_url}?status=planned&q=loyalty", headers=voter_one)
+    assert filtered.status_code == 200
+    assert [item["id"] for item in filtered.json()["initiatives"]] == [low_priority["id"]]
+
+    removed_vote = client.put(
+        f"{board_url}/initiatives/{high_priority['id']}/vote",
+        json={"value": None},
+        headers=voter_one,
+    )
+    assert removed_vote.status_code == 200
+    assert removed_vote.json()["downvotes"] == 0
+    assert removed_vote.json()["viewer_vote"] is None
+
+
+def test_public_vote_requires_a_browser_identifier(client, auth_headers):
+    headers = auth_headers()
+    org = create_org(client, headers)
+    initiative = create_initiative(client, headers, org["id"], "Online booking")
+
+    response = client.put(
+        f"/api/boards/{org['feedback_token']}/initiatives/{initiative['id']}/vote",
+        json={"value": 1},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing visitor identifier"

--- a/backend/tests/test_locations.py
+++ b/backend/tests/test_locations.py
@@ -1,0 +1,314 @@
+from datetime import date
+
+from sqlalchemy import select
+
+from app.models import Digest, DigestStatus, User
+from conftest import TestingSessionLocal
+
+
+def create_org(client, headers, name="Diner Group"):
+    response = client.post("/organizations", json={"name": name}, headers=headers)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_new_organization_gets_a_default_location_and_preserves_public_token(client, auth_headers):
+    headers = auth_headers()
+    org = create_org(client, headers)
+
+    locations = client.get(f"/organizations/{org['id']}/locations", headers=headers)
+    assert locations.status_code == 200, locations.text
+    assert len(locations.json()) == 1
+    default_location = locations.json()[0]
+    assert default_location["name"] == org["name"]
+    assert default_location["is_default"] is True
+    assert default_location["feedback_token"] == org["feedback_token"]
+    assert default_location["access_role"] == "organization_admin"
+
+    public_info = client.get(f"/api/feedback/{org['feedback_token']}")
+    assert public_info.status_code == 200, public_info.text
+    assert public_info.json()["location_id"] == default_location["id"]
+    assert public_info.json()["location_name"] == org["name"]
+
+
+def test_location_manager_only_sees_and_manages_assigned_location(client, auth_headers):
+    owner_headers = auth_headers("owner@example.com")
+    org = create_org(client, owner_headers)
+    default_location = client.get(
+        f"/organizations/{org['id']}/locations",
+        headers=owner_headers,
+    ).json()[0]
+    second_response = client.post(
+        f"/organizations/{org['id']}/locations",
+        json={
+            "name": "Downtown",
+            "address": "123 Main Street",
+            "timezone": "America/Chicago",
+        },
+        headers=owner_headers,
+    )
+    assert second_response.status_code == 201, second_response.text
+    second_location = second_response.json()
+
+    manager_headers = auth_headers("manager@example.com")
+    invite = client.post(
+        f"/organizations/{org['id']}/invites",
+        json={
+            "role": "location_admin",
+            "location_id": second_location["id"],
+        },
+        headers=owner_headers,
+    )
+    assert invite.status_code == 201, invite.text
+    accepted = client.post(
+        "/invites/accept",
+        json={"token": invite.json()["token"]},
+        headers=manager_headers,
+    )
+    assert accepted.status_code == 200, accepted.text
+
+    visible_locations = client.get(
+        f"/organizations/{org['id']}/locations",
+        headers=manager_headers,
+    )
+    assert visible_locations.status_code == 200
+    assert [location["id"] for location in visible_locations.json()] == [second_location["id"]]
+    assert visible_locations.json()[0]["access_role"] == "location_admin"
+
+    created = client.post(
+        f"/organizations/{org['id']}/initiatives",
+        json={
+            "title": "Downtown patio",
+            "description": "Add shaded seating.",
+            "location_id": second_location["id"],
+        },
+        headers=manager_headers,
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["location_id"] == second_location["id"]
+
+    denied = client.post(
+        f"/organizations/{org['id']}/initiatives",
+        json={
+            "title": "Private default item",
+            "description": "Should not be visible.",
+            "location_id": default_location["id"],
+        },
+        headers=manager_headers,
+    )
+    assert denied.status_code == 404
+
+    aggregate = client.get(
+        f"/organizations/{org['id']}/initiatives",
+        headers=owner_headers,
+    )
+    assert aggregate.status_code == 200
+    assert [item["id"] for item in aggregate.json()] == [created.json()["id"]]
+
+
+def test_members_can_use_each_explicit_organization_or_location_access_level(client, auth_headers):
+    owner_headers = auth_headers("roles-owner@example.com")
+    org = create_org(client, owner_headers)
+    second_location = client.post(
+        f"/organizations/{org['id']}/locations",
+        json={"name": "Northside"},
+        headers=owner_headers,
+    ).json()
+
+    member_headers = auth_headers("roles-member@example.com")
+    invite = client.post(
+        f"/organizations/{org['id']}/invites",
+        json={"role": "organization_viewer"},
+        headers=owner_headers,
+    )
+    assert invite.status_code == 201, invite.text
+    accepted = client.post("/invites/accept", json={"token": invite.json()["token"]}, headers=member_headers)
+    assert accepted.status_code == 200
+    assert accepted.json()["role"] == "organization_viewer"
+
+    members = client.get(f"/organizations/{org['id']}/members", headers=owner_headers).json()
+    member = next(item for item in members if item["email"] == "roles-member@example.com")
+    assert member["role"] == "organization_viewer"
+    assert len(client.get(f"/organizations/{org['id']}/locations", headers=member_headers).json()) == 2
+
+    location_admin = client.patch(
+        f"/organizations/{org['id']}/members/{member['user_id']}",
+        json={"role": "location_admin"},
+        headers=owner_headers,
+    )
+    assert location_admin.status_code == 200, location_admin.text
+    assert location_admin.json()["role"] == "location_admin"
+    assert location_admin.json()["location_assignments"][0]["role"] == "manager"
+
+    assignments = client.put(
+        f"/organizations/{org['id']}/members/{member['user_id']}/locations",
+        json={"assignments": [{"location_id": second_location["id"], "role": "manager"}]},
+        headers=owner_headers,
+    )
+    assert assignments.status_code == 200, assignments.text
+    assert assignments.json()["role"] == "location_admin"
+
+    location_viewer = client.patch(
+        f"/organizations/{org['id']}/members/{member['user_id']}",
+        json={"role": "location_viewer"},
+        headers=owner_headers,
+    )
+    assert location_viewer.status_code == 200
+    assert location_viewer.json()["location_assignments"][0]["role"] == "viewer"
+
+    organization_admin = client.patch(
+        f"/organizations/{org['id']}/members/{member['user_id']}",
+        json={"role": "organization_admin"},
+        headers=owner_headers,
+    )
+    assert organization_admin.status_code == 200
+    assert organization_admin.json()["role"] == "organization_admin"
+    assert organization_admin.json()["location_assignments"] == []
+
+
+def test_public_roadmaps_are_isolated_by_location_token(client, auth_headers):
+    headers = auth_headers()
+    org = create_org(client, headers)
+    default_location = client.get(
+        f"/organizations/{org['id']}/locations",
+        headers=headers,
+    ).json()[0]
+    second_location = client.post(
+        f"/organizations/{org['id']}/locations",
+        json={"name": "Uptown"},
+        headers=headers,
+    ).json()
+
+    default_item = client.post(
+        f"/organizations/{org['id']}/initiatives",
+        json={
+            "title": "Default item",
+            "description": "Default only",
+            "location_id": default_location["id"],
+        },
+        headers=headers,
+    ).json()
+    second_item = client.post(
+        f"/organizations/{org['id']}/initiatives",
+        json={
+            "title": "Uptown item",
+            "description": "Uptown only",
+            "location_id": second_location["id"],
+        },
+        headers=headers,
+    ).json()
+
+    default_board = client.get(f"/api/boards/{default_location['feedback_token']}")
+    second_board = client.get(f"/api/boards/{second_location['feedback_token']}")
+    assert [item["id"] for item in default_board.json()["initiatives"]] == [default_item["id"]]
+    assert [item["id"] for item in second_board.json()["initiatives"]] == [second_item["id"]]
+    assert second_board.json()["location_name"] == "Uptown"
+
+    voter = {"X-Visitor-ID": "7a8d7f1b-e1dd-48f6-9dcb-1f773c2d957e"}
+    cross_location_vote = client.put(
+        f"/api/boards/{default_location['feedback_token']}/initiatives/{second_item['id']}/vote",
+        json={"value": 1},
+        headers=voter,
+    )
+    assert cross_location_vote.status_code == 404
+
+
+def test_location_manager_can_reopen_drafts_while_viewer_waits_for_publish(client, auth_headers):
+    owner_headers = auth_headers("digest-owner@example.com")
+    org = create_org(client, owner_headers)
+    location = client.post(
+        f"/organizations/{org['id']}/locations",
+        json={"name": "Downtown"},
+        headers=owner_headers,
+    ).json()
+
+    manager_headers = auth_headers("digest-manager@example.com")
+    manager_invite = client.post(
+        f"/organizations/{org['id']}/invites",
+        json={
+            "role": "location_admin",
+            "location_id": location["id"],
+        },
+        headers=owner_headers,
+    ).json()
+    client.post(
+        "/invites/accept",
+        json={"token": manager_invite["token"]},
+        headers=manager_headers,
+    )
+
+    viewer_headers = auth_headers("digest-viewer@example.com")
+    viewer_invite = client.post(
+        f"/organizations/{org['id']}/invites",
+        json={
+            "role": "location_viewer",
+            "location_id": location["id"],
+        },
+        headers=owner_headers,
+    ).json()
+    client.post(
+        "/invites/accept",
+        json={"token": viewer_invite["token"]},
+        headers=viewer_headers,
+    )
+
+    with TestingSessionLocal() as db:
+        manager = db.scalar(select(User).where(User.email == "digest-manager@example.com"))
+        digest = Digest(
+            organization_id=org["id"],
+            location_id=location["id"],
+            status=DigestStatus.DRAFT,
+            period_start=date(2026, 7, 20),
+            period_end=date(2026, 7, 26),
+            summary="A draft location summary.",
+            insights=["Guests want online booking."],
+            immediate_actions=["Add a reservation link."],
+            long_term_goals=["Launch online reservations."],
+            feedback_count=1,
+            generated_by=manager.id,
+        )
+        db.add(digest)
+        db.commit()
+        digest_id = digest.id
+
+    manager_list = client.get(
+        f"/organizations/{org['id']}/digests",
+        params={"location_id": location["id"]},
+        headers=manager_headers,
+    )
+    assert manager_list.status_code == 200, manager_list.text
+    assert [item["id"] for item in manager_list.json()] == [digest_id]
+    assert manager_list.json()[0]["location_name"] == "Downtown"
+
+    manager_detail = client.get(
+        f"/organizations/{org['id']}/digests/{digest_id}",
+        headers=manager_headers,
+    )
+    assert manager_detail.status_code == 200, manager_detail.text
+
+    viewer_list = client.get(
+        f"/organizations/{org['id']}/digests",
+        params={"location_id": location["id"]},
+        headers=viewer_headers,
+    )
+    assert viewer_list.status_code == 200
+    assert viewer_list.json() == []
+
+    viewer_detail = client.get(
+        f"/organizations/{org['id']}/digests/{digest_id}",
+        headers=viewer_headers,
+    )
+    assert viewer_detail.status_code == 404
+
+    published = client.post(
+        f"/organizations/{org['id']}/digests/{digest_id}/publish",
+        headers=manager_headers,
+    )
+    assert published.status_code == 200, published.text
+
+    viewer_list = client.get(
+        f"/organizations/{org['id']}/digests",
+        params={"location_id": location["id"]},
+        headers=viewer_headers,
+    )
+    assert [item["id"] for item in viewer_list.json()] == [digest_id]

--- a/backend/tests/test_organizations.py
+++ b/backend/tests/test_organizations.py
@@ -8,7 +8,7 @@ def test_create_and_list_organization(client, auth_headers):
     headers = auth_headers()
     org = create_org(client, headers)
     assert org["name"] == "Acme Diner"
-    assert org["role"] == "admin"
+    assert org["role"] == "organization_admin"
     assert org["feedback_token"]
 
     listing = client.get("/organizations", headers=headers)

--- a/backend/tests/test_social_connections.py
+++ b/backend/tests/test_social_connections.py
@@ -1,0 +1,340 @@
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+import app.main as main_module
+import app.social as social_module
+from app.config import Settings
+from app.models import SocialConnection
+from app.social import (
+    PROVIDER_DETAILS,
+    build_authorization_url,
+    exchange_social_code,
+    fetch_social_identity,
+    provider_configured,
+)
+from conftest import TestingSessionLocal
+
+
+def create_org(client, headers, name="Connected Diner"):
+    response = client.post("/organizations", json={"name": name}, headers=headers)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_instagram_uses_direct_business_login_configuration():
+    settings = Settings(
+        api_base_url="https://api.fivestar.fyi",
+        meta_client_id="facebook-client",
+        meta_client_secret="facebook-secret",
+        instagram_client_id="instagram-client",
+        instagram_client_secret="instagram-secret",
+    )
+
+    assert provider_configured("facebook", settings) is True
+    assert provider_configured("instagram", settings) is True
+    assert PROVIDER_DETAILS["instagram"]["scopes"] == [
+        "instagram_business_basic",
+        "instagram_business_content_publish",
+    ]
+
+    authorization_url = build_authorization_url("instagram", "oauth-state", settings)
+    parsed = urlparse(authorization_url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.netloc == "www.instagram.com"
+    assert parsed.path == "/oauth/authorize"
+    assert query["client_id"] == ["instagram-client"]
+    assert query["redirect_uri"] == [
+        "https://api.fivestar.fyi/oauth/social/instagram/callback"
+    ]
+    assert query["scope"] == [
+        "instagram_business_basic,instagram_business_content_publish"
+    ]
+    assert query["force_reauth"] == ["true"]
+    assert query["state"] == ["oauth-state"]
+
+
+def test_instagram_exchanges_for_long_lived_token_and_loads_identity(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(("client", kwargs))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def post(self, url, **kwargs):
+            calls.append(("post", url, kwargs))
+            return httpx.Response(
+                200,
+                json={"access_token": "short-token", "user_id": "ig-123"},
+            )
+
+        def get(self, url, **kwargs):
+            calls.append(("get", url, kwargs))
+            if url.endswith("/access_token"):
+                return httpx.Response(
+                    200,
+                    json={"access_token": "long-token", "expires_in": 5_184_000},
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "user_id": "ig-123",
+                    "username": "fivestar",
+                    "account_type": "BUSINESS",
+                },
+            )
+
+    monkeypatch.setattr(social_module.httpx, "Client", FakeClient)
+    settings = Settings(
+        api_base_url="https://fivestar.fyi",
+        instagram_client_id="instagram-client",
+        instagram_client_secret="instagram-secret",
+    )
+
+    token_data = exchange_social_code(
+        "instagram",
+        "authorization-code",
+        settings,
+    )
+    identity = fetch_social_identity("instagram", token_data)
+
+    assert token_data["access_token"] == "long-token"
+    assert token_data["expires_in"] == 5_184_000
+    assert identity == {
+        "id": "ig-123",
+        "name": "fivestar",
+        "data": {
+            "username": "fivestar",
+            "account_type": "BUSINESS",
+            "profile_picture_url": None,
+        },
+    }
+    token_request = next(call for call in calls if call[:2] == ("post", "https://api.instagram.com/oauth/access_token"))
+    assert token_request[2]["data"]["client_id"] == "instagram-client"
+    assert token_request[2]["data"]["redirect_uri"] == (
+        "https://fivestar.fyi/oauth/social/instagram/callback"
+    )
+    long_lived_request = next(
+        call
+        for call in calls
+        if call[:2] == ("get", "https://graph.instagram.com/access_token")
+    )
+    assert long_lived_request[2]["params"] == {
+        "grant_type": "ig_exchange_token",
+        "client_secret": "instagram-secret",
+        "access_token": "short-token",
+    }
+
+
+def test_social_connections_are_admin_only_and_report_setup_state(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    owner_headers = auth_headers("social-owner@example.com")
+    org = create_org(client, owner_headers)
+    monkeypatch.setattr(main_module.settings, "meta_client_id", "")
+    monkeypatch.setattr(main_module.settings, "meta_client_secret", "")
+
+    listing = client.get(
+        f"/organizations/{org['id']}/social-connections",
+        headers=owner_headers,
+    )
+    assert listing.status_code == 200, listing.text
+    assert [item["provider"] for item in listing.json()] == [
+        "facebook",
+        "instagram",
+        "tiktok",
+    ]
+    assert all(item["connected"] is False for item in listing.json())
+    assert listing.json()[0]["configured"] is False
+    assert [item["publishing_enabled"] for item in listing.json()] == [
+        True,
+        True,
+        False,
+    ]
+
+    unconfigured = client.post(
+        f"/organizations/{org['id']}/social-connections/facebook/authorize",
+        headers=owner_headers,
+    )
+    assert unconfigured.status_code == 503
+
+    viewer_headers = auth_headers("social-viewer@example.com")
+    invite = client.post(
+        f"/organizations/{org['id']}/invites",
+        json={"role": "organization_viewer"},
+        headers=owner_headers,
+    ).json()
+    accepted = client.post(
+        "/invites/accept",
+        json={"token": invite["token"]},
+        headers=viewer_headers,
+    )
+    assert accepted.status_code == 200
+    denied = client.get(
+        f"/organizations/{org['id']}/social-connections",
+        headers=viewer_headers,
+    )
+    assert denied.status_code == 403
+
+
+def test_social_oauth_callback_persists_encrypted_connection_and_disconnects(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    headers = auth_headers("oauth-owner@example.com")
+    org = create_org(client, headers)
+    monkeypatch.setattr(main_module.settings, "meta_client_id", "meta-client")
+    monkeypatch.setattr(main_module.settings, "meta_client_secret", "meta-secret")
+    monkeypatch.setattr(main_module.settings, "api_base_url", "http://testserver")
+    monkeypatch.setattr(
+        main_module,
+        "exchange_social_code",
+        lambda provider, code, settings: {
+            "access_token": "plain-access-token",
+            "expires_in": 3600,
+            "scope": "pages_show_list,pages_manage_posts",
+        },
+    )
+    available_pages = [
+        {
+            "id": "page-123",
+            "name": "Connected Diner",
+            "access_token": "page-access-token",
+            "tasks": ["CREATE_CONTENT", "MANAGE"],
+            "instagram": {
+                "id": "ig-456",
+                "username": "connected_diner",
+                "name": "Connected Diner",
+                "profile_picture_url": None,
+            },
+        }
+    ]
+    monkeypatch.setattr(
+        main_module,
+        "fetch_facebook_pages",
+        lambda access_token: available_pages,
+    )
+
+    authorization = client.post(
+        f"/organizations/{org['id']}/social-connections/facebook/authorize",
+        headers=headers,
+    )
+    assert authorization.status_code == 200, authorization.text
+    authorization_url = authorization.json()["authorization_url"]
+    parsed = urlparse(authorization_url)
+    assert parsed.netloc == "www.facebook.com"
+    state_value = parse_qs(parsed.query)["state"][0]
+
+    callback = client.get(
+        "/oauth/social/facebook/callback",
+        params={"state": state_value, "code": "provider-code"},
+        follow_redirects=False,
+    )
+    assert callback.status_code == 303, callback.text
+    assert f"/org/{org['id']}/social" in callback.headers["location"]
+    assert "social=selection_required" in callback.headers["location"]
+    setup_token = parse_qs(urlparse(callback.headers["location"]).query)["setup"][0]
+
+    options = client.get(
+        f"/organizations/{org['id']}/social-connections/facebook/options",
+        params={"setup": setup_token},
+        headers=headers,
+    )
+    assert options.status_code == 200, options.text
+    assert options.json() == {
+        "pages": [
+            {
+                "id": "page-123",
+                "name": "Connected Diner",
+                "tasks": ["CREATE_CONTENT", "MANAGE"],
+                "instagram": {
+                    "id": "ig-456",
+                    "username": "connected_diner",
+                    "name": "Connected Diner",
+                    "profile_picture_url": None,
+                },
+            }
+        ]
+    }
+
+    completed = client.post(
+        f"/organizations/{org['id']}/social-connections/facebook/complete",
+        json={"setup_token": setup_token, "page_id": "page-123"},
+        headers=headers,
+    )
+    assert completed.status_code == 200, completed.text
+
+    listing = client.get(
+        f"/organizations/{org['id']}/social-connections",
+        headers=headers,
+    )
+    facebook = listing.json()[0]
+    instagram = listing.json()[1]
+    assert facebook["connected"] is True
+    assert facebook["status"] == "connected"
+    assert facebook["provider_account_name"] == "Connected Diner"
+    assert facebook["provider_account_id"] == "page-123"
+    assert facebook["connection_method"] == "facebook_login"
+    assert facebook["scopes"] == ["pages_show_list", "pages_manage_posts"]
+    assert instagram["connected"] is True
+    assert instagram["provider_account_name"] == "connected_diner"
+    assert instagram["provider_account_id"] == "ig-456"
+    assert instagram["linked_page_name"] == "Connected Diner"
+
+    with TestingSessionLocal() as db:
+        saved_facebook = db.query(SocialConnection).filter_by(
+            organization_id=org["id"],
+            provider="facebook",
+        ).one()
+        saved_instagram = db.query(SocialConnection).filter_by(
+            organization_id=org["id"],
+            provider="instagram",
+        ).one()
+        assert saved_facebook.access_token_encrypted != "page-access-token"
+        assert "page-access-token" not in saved_facebook.access_token_encrypted
+        assert saved_facebook.refresh_token_encrypted != "plain-access-token"
+        assert "plain-access-token" not in saved_facebook.refresh_token_encrypted
+        assert saved_instagram.access_token_encrypted != "page-access-token"
+
+    setup_replay = client.post(
+        f"/organizations/{org['id']}/social-connections/facebook/complete",
+        json={"setup_token": setup_token, "page_id": "page-123"},
+        headers=headers,
+    )
+    assert setup_replay.status_code == 400
+
+    replay = client.get(
+        "/oauth/social/facebook/callback",
+        params={"state": state_value, "code": "provider-code"},
+        follow_redirects=False,
+    )
+    assert replay.status_code == 400
+
+    revoked = []
+    monkeypatch.setattr(
+        main_module,
+        "revoke_social_token",
+        lambda provider, encrypted_token, settings: revoked.append(provider),
+    )
+    disconnected = client.delete(
+        f"/organizations/{org['id']}/social-connections/facebook",
+        headers=headers,
+    )
+    assert disconnected.status_code == 204
+    assert revoked == ["facebook"]
+    listing = client.get(
+        f"/organizations/{org['id']}/social-connections",
+        headers=headers,
+    )
+    assert listing.json()[0]["connected"] is False
+    assert listing.json()[1]["connected"] is False

--- a/backend/tests/test_social_posts.py
+++ b/backend/tests/test_social_posts.py
@@ -1,0 +1,294 @@
+from datetime import datetime, timedelta, timezone
+
+import app.main as main_module
+from app.models import SocialConnection, User
+from app.schemas import SocialDraftContent
+from app.social import SocialProviderError, encrypt_token
+from conftest import TestingSessionLocal
+
+
+def create_org(client, headers, name="Publishing Diner"):
+    response = client.post("/organizations", json={"name": name}, headers=headers)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def add_connection(
+    *,
+    organization_id: int,
+    user_email: str,
+    provider: str,
+    account_id: str,
+    account_name: str,
+) -> None:
+    with TestingSessionLocal() as db:
+        user = db.query(User).filter_by(email=user_email).one()
+        db.add(
+            SocialConnection(
+                organization_id=organization_id,
+                provider=provider,
+                status="connected",
+                provider_account_id=account_id,
+                provider_account_name=account_name,
+                access_token_encrypted=encrypt_token(f"{provider}-access-token"),
+                scopes=[],
+                provider_data={
+                    "auth_type": "facebook_login"
+                    if provider in {"facebook", "instagram"}
+                    else "oauth",
+                    "facebook_page_name": account_name
+                    if provider == "instagram"
+                    else None,
+                },
+                connected_by=user.id,
+            )
+        )
+        db.commit()
+
+
+def test_social_posts_require_admin_and_connected_destinations(
+    client,
+    auth_headers,
+):
+    owner_headers = auth_headers("post-owner@example.com")
+    org = create_org(client, owner_headers)
+
+    missing_connection = client.post(
+        f"/organizations/{org['id']}/social-posts",
+        json={
+            "master_caption": "A new special",
+            "targets": [{"provider": "facebook", "content": "A new special"}],
+            "media_urls": [],
+        },
+        headers=owner_headers,
+    )
+    assert missing_connection.status_code == 409
+
+    unsupported_provider = client.post(
+        f"/organizations/{org['id']}/social-posts",
+        json={
+            "master_caption": "A new special",
+            "targets": [{"provider": "tiktok", "content": "A new special"}],
+            "media_urls": ["https://images.example.com/special.jpg"],
+        },
+        headers=owner_headers,
+    )
+    assert unsupported_provider.status_code == 422
+
+    add_connection(
+        organization_id=org["id"],
+        user_email="post-owner@example.com",
+        provider="instagram",
+        account_id="ig-1",
+        account_name="publishing_diner",
+    )
+    missing_instagram_media = client.post(
+        f"/organizations/{org['id']}/social-posts",
+        json={
+            "master_caption": "A new special",
+            "targets": [{"provider": "instagram", "content": "A new special"}],
+            "media_urls": [],
+        },
+        headers=owner_headers,
+    )
+    assert missing_instagram_media.status_code == 422
+
+    viewer_headers = auth_headers("post-viewer@example.com")
+    invite = client.post(
+        f"/organizations/{org['id']}/invites",
+        json={"role": "organization_viewer"},
+        headers=owner_headers,
+    ).json()
+    accepted = client.post(
+        "/invites/accept",
+        json={"token": invite["token"]},
+        headers=viewer_headers,
+    )
+    assert accepted.status_code == 200
+    denied = client.get(
+        f"/organizations/{org['id']}/social-posts",
+        headers=viewer_headers,
+    )
+    assert denied.status_code == 403
+
+
+def test_social_draft_generation_is_authenticated_and_structured(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    headers = auth_headers("draft-owner@example.com")
+    org = create_org(client, headers)
+    monkeypatch.setattr(main_module.settings, "openai_api_key", "test-key")
+    calls = []
+
+    def fake_generate(*, api_key, content):
+        calls.append((api_key, content))
+        return SocialDraftContent(
+            facebook="Facebook version",
+            instagram="Instagram version #local",
+            tiktok="TikTok version",
+        )
+
+    monkeypatch.setattr(main_module, "generate_social_drafts", fake_generate)
+    response = client.post(
+        f"/organizations/{org['id']}/social-posts/drafts/generate",
+        json={"master_caption": "We have a new patio."},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["instagram"] == "Instagram version #local"
+    assert calls == [("test-key", "We have a new patio.")]
+
+    unauthenticated = client.post(
+        f"/organizations/{org['id']}/social-posts/drafts/generate",
+        json={"master_caption": "We have a new patio."},
+    )
+    assert unauthenticated.status_code == 401
+
+
+def test_social_posts_schedule_and_publish_to_each_selected_destination(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    email = "publisher@example.com"
+    headers = auth_headers(email)
+    org = create_org(client, headers)
+    add_connection(
+        organization_id=org["id"],
+        user_email=email,
+        provider="facebook",
+        account_id="page-1",
+        account_name="Publishing Diner",
+    )
+    add_connection(
+        organization_id=org["id"],
+        user_email=email,
+        provider="instagram",
+        account_id="ig-1",
+        account_name="publishing_diner",
+    )
+
+    future = datetime.now(timezone.utc) + timedelta(hours=2)
+    scheduled = client.post(
+        f"/organizations/{org['id']}/social-posts",
+        json={
+            "master_caption": "Tomorrow's special",
+            "targets": [
+                {"provider": "facebook", "content": "Facebook special"},
+            ],
+            "media_urls": [],
+            "scheduled_at": future.isoformat(),
+        },
+        headers=headers,
+    )
+    assert scheduled.status_code == 201, scheduled.text
+    assert scheduled.json()["status"] == "scheduled"
+
+    publish_calls = []
+
+    def fake_publish(provider, **kwargs):
+        publish_calls.append((provider, kwargs))
+        return f"{provider}-post-123"
+
+    monkeypatch.setattr(main_module, "publish_social_content", fake_publish)
+    created = client.post(
+        f"/organizations/{org['id']}/social-posts",
+        json={
+            "master_caption": "Our new summer menu",
+            "targets": [
+                {"provider": "facebook", "content": "Facebook menu post"},
+                {"provider": "instagram", "content": "Instagram menu post"},
+            ],
+            "media_urls": ["https://images.example.com/menu.jpg"],
+        },
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+
+    published = client.post(
+        f"/organizations/{org['id']}/social-posts/{created.json()['id']}/publish",
+        headers=headers,
+    )
+    assert published.status_code == 200, published.text
+    assert published.json()["status"] == "published"
+    assert {target["status"] for target in published.json()["targets"]} == {
+        "published"
+    }
+    assert [call[0] for call in publish_calls] == ["facebook", "instagram"]
+    assert publish_calls[0][1]["content"] == "Facebook menu post"
+    assert publish_calls[1][1]["media_urls"] == [
+        "https://images.example.com/menu.jpg"
+    ]
+
+    listing = client.get(
+        f"/organizations/{org['id']}/social-posts",
+        headers=headers,
+    )
+    assert listing.status_code == 200, listing.text
+    assert [post["status"] for post in listing.json()] == [
+        "published",
+        "scheduled",
+    ]
+
+
+def test_social_post_reports_partial_provider_failure(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    email = "partial-publisher@example.com"
+    headers = auth_headers(email)
+    org = create_org(client, headers)
+    for provider, account_id, account_name in (
+        ("facebook", "page-1", "Publishing Diner"),
+        ("instagram", "ig-1", "publishing_diner"),
+    ):
+        add_connection(
+            organization_id=org["id"],
+            user_email=email,
+            provider=provider,
+            account_id=account_id,
+            account_name=account_name,
+        )
+
+    def partially_failing_publish(provider, **kwargs):
+        if provider == "instagram":
+            raise SocialProviderError("Instagram rejected the media")
+        return "facebook-post-123"
+
+    monkeypatch.setattr(
+        main_module,
+        "publish_social_content",
+        partially_failing_publish,
+    )
+    created = client.post(
+        f"/organizations/{org['id']}/social-posts",
+        json={
+            "master_caption": "A shared update",
+            "targets": [
+                {"provider": "facebook", "content": "Facebook update"},
+                {"provider": "instagram", "content": "Instagram update"},
+            ],
+            "media_urls": ["https://images.example.com/update.jpg"],
+        },
+        headers=headers,
+    )
+    published = client.post(
+        f"/organizations/{org['id']}/social-posts/{created.json()['id']}/publish",
+        headers=headers,
+    )
+    assert published.status_code == 200, published.text
+    assert published.json()["status"] == "partial_failure"
+    statuses = {
+        target["provider"]: target["status"]
+        for target in published.json()["targets"]
+    }
+    assert statuses == {"facebook": "published", "instagram": "failed"}
+    instagram = next(
+        target
+        for target in published.json()["targets"]
+        if target["provider"] == "instagram"
+    )
+    assert instagram["error"] == "Instagram rejected the media"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,41 +1,109 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
-import { listOrganizations, me } from "./api";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, Navigate, NavLink, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { listLocations, listOrganizations, me } from "./api";
 import AuthPage from "./components/AuthPage";
 import BrandName from "./components/BrandName";
 import CreateOrgModal from "./components/CreateOrgModal";
+import DashboardWidget from "./components/DashboardWidget";
 import DigestManager from "./components/DigestManager";
 import DigestsPage from "./components/DigestsPage";
 import FeedbackPage from "./components/FeedbackPage";
+import FeedPage from "./components/FeedPage";
 import InviteAcceptPage from "./components/InviteAcceptPage";
+import InitiativesManager from "./components/InitiativesManager";
 import MarketingPage from "./components/MarketingPage";
+import LocationsPage from "./components/LocationsPage";
+import LocationSwitcher from "./components/LocationSwitcher";
 import OrganizationSwitcher from "./components/OrganizationSwitcher";
 import OrgSettingsPage from "./components/OrgSettingsPage";
 import ResetPasswordPage from "./components/ResetPasswordPage";
 import SearchPage from "./components/SearchPage";
 import TopbarSearch from "./components/TopbarSearch";
+import VotingBoardPage from "./components/VotingBoardPage";
 
 const TOKEN_KEY = "five-star-token";
 const CURRENT_ORG_KEY = "five-star-current-org";
+const CURRENT_LOCATION_PREFIX = "five-star-current-location";
+const SIDEBAR_KEY = "five-star-sidebar-open";
 const LOGO_SRC = `${import.meta.env.BASE_URL}brand/five-star-logo.svg`;
+const ASTERISK_SRC = `${import.meta.env.BASE_URL}brand/five-star-asterisk.svg`;
+const ACCESS_ROLE_LABELS = {
+  organization_admin: "Organization admin",
+  organization_viewer: "Organization viewer",
+  location_admin: "Location admin",
+  location_viewer: "Location viewer",
+};
+
+function accessRoleLabel(role) {
+  return ACCESS_ROLE_LABELS[role] || role || "Member";
+}
+
+const JOURNEY_MILESTONES = [
+  {
+    title: "Start your journey",
+    description: "Create an account and log in to Five Star.",
+  },
+  {
+    title: "Collect and report",
+    description: "Collect 10 feedback submissions and publish a feedback report.",
+  },
+  {
+    title: "Share your roadmap",
+    description: "Publish initiatives and use the roadmap to show what you’re working on.",
+  },
+  {
+    title: "Earn a 4.8+ reputation",
+    description: "Maintain a 4.8 or higher average across your connected review boards.",
+  },
+  {
+    title: "Earn a Five Star recognition",
+    description: "Qualify for the annual Five Star recognitions, with opportunities for free advertising and public voting.",
+  },
+];
 
 export default function App() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [token, setToken] = useState(() => localStorage.getItem(TOKEN_KEY) || "");
   const [user, setUser] = useState(null);
   const [organizations, setOrganizations] = useState([]);
+  const [locations, setLocations] = useState([]);
+  const [currentLocationId, setCurrentLocationId] = useState("all");
   const [currentOrgId, setCurrentOrgId] = useState(() => {
     const saved = localStorage.getItem(CURRENT_ORG_KEY);
     return saved ? Number(saved) : null;
   });
   const [showCreateOrg, setShowCreateOrg] = useState(false);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const locationRequestIdRef = useRef(0);
+  const [isMenuOpen, setIsMenuOpen] = useState(() => {
+    if (window.innerWidth <= 900) return false;
+    return localStorage.getItem(SIDEBAR_KEY) !== "false";
+  });
 
   const isAuthenticated = useMemo(() => Boolean(token && user), [token, user]);
-  const currentOrg = useMemo(
-    () => organizations.find((o) => o.id === currentOrgId) || organizations[0] || null,
-    [organizations, currentOrgId]
+  const routeOrgId = useMemo(
+    () => Number(location.pathname.match(/^\/org\/(\d+)/)?.[1]) || null,
+    [location.pathname]
   );
+  const currentOrg = useMemo(
+    () => (
+      routeOrgId
+        ? organizations.find((organization) => organization.id === routeOrgId) || null
+        : organizations.find((organization) => organization.id === currentOrgId) || organizations[0] || null
+    ),
+    [organizations, currentOrgId, routeOrgId]
+  );
+  const currentLocation = useMemo(
+    () => locations.find(
+      (item) => item.id === Number(currentLocationId) && item.organization_id === currentOrg?.id
+    ) || null,
+    [locations, currentLocationId, currentOrg?.id]
+  );
+  const selectedLocationId = currentLocation?.id || null;
+  const locationScopeLabel = currentLocationId === "all"
+    ? "All locations"
+    : currentLocation?.name || "All locations";
+  const canManageCurrentLocation = Boolean(currentOrg?.can_manage_organization) || Boolean(currentLocation?.can_manage);
   const isAppRoute = location.pathname === "/dashboard" || location.pathname.startsWith("/org/");
 
   const loadOrganizations = useCallback(
@@ -79,19 +147,82 @@ export default function App() {
   }, [token, loadOrganizations]);
 
   useEffect(() => {
-    setIsMenuOpen(false);
+    if (window.innerWidth <= 900) setIsMenuOpen(false);
   }, [location.pathname, isAuthenticated]);
 
+  useEffect(() => {
+    if (!routeOrgId) return;
+    const routeOrganization = organizations.find((organization) => organization.id === routeOrgId);
+    if (routeOrganization && routeOrgId !== currentOrgId) {
+      locationRequestIdRef.current += 1;
+      setCurrentOrgId(routeOrgId);
+      localStorage.setItem(CURRENT_ORG_KEY, String(routeOrgId));
+      setLocations([]);
+      setCurrentLocationId("all");
+    } else if (user && organizations.length > 0 && !routeOrganization) {
+      navigate("/dashboard", { replace: true });
+    }
+  }, [routeOrgId, organizations, currentOrgId, navigate, user]);
+
+  const loadCurrentLocations = useCallback(async () => {
+    const requestId = ++locationRequestIdRef.current;
+    if (!token || !currentOrg?.id) {
+      if (requestId === locationRequestIdRef.current) setLocations([]);
+      return [];
+    }
+    try {
+      const availableLocations = await listLocations(token, currentOrg.id);
+      if (requestId !== locationRequestIdRef.current) return [];
+      setLocations(availableLocations);
+      const storageKey = `${CURRENT_LOCATION_PREFIX}-${currentOrg.id}`;
+      const saved = localStorage.getItem(storageKey);
+      const savedLocationId = Number(saved);
+      let nextScope;
+      if (saved === "all" && currentOrg.can_view_all_locations) {
+        nextScope = "all";
+      } else if (savedLocationId && availableLocations.some((item) => item.id === savedLocationId)) {
+        nextScope = savedLocationId;
+      } else if (currentOrg.can_view_all_locations) {
+        nextScope = "all";
+      } else {
+        nextScope = availableLocations[0]?.id || "all";
+      }
+      setCurrentLocationId(nextScope);
+      localStorage.setItem(storageKey, String(nextScope));
+      return availableLocations;
+    } catch {
+      if (requestId === locationRequestIdRef.current) setLocations([]);
+      return [];
+    }
+  }, [token, currentOrg?.id, currentOrg?.can_view_all_locations]);
+
+  useEffect(() => {
+    loadCurrentLocations();
+  }, [loadCurrentLocations]);
+
   function handleOrgChange(orgId) {
+    locationRequestIdRef.current += 1;
     setCurrentOrgId(orgId);
     localStorage.setItem(CURRENT_ORG_KEY, String(orgId));
+    setLocations([]);
+    setCurrentLocationId("all");
+    navigate("/dashboard");
+  }
+
+  function handleLocationChange(locationId) {
+    setCurrentLocationId(locationId);
+    if (currentOrg) {
+      localStorage.setItem(`${CURRENT_LOCATION_PREFIX}-${currentOrg.id}`, String(locationId));
+    }
   }
 
   function handleOrgCreated(org) {
+    locationRequestIdRef.current += 1;
     setOrganizations((prev) => [...prev, org]);
     setCurrentOrgId(org.id);
     localStorage.setItem(CURRENT_ORG_KEY, String(org.id));
     setShowCreateOrg(false);
+    navigate("/dashboard");
   }
 
   function handleAuthenticated(accessToken, currentUser) {
@@ -101,32 +232,67 @@ export default function App() {
   }
 
   function logout() {
+    locationRequestIdRef.current += 1;
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(CURRENT_ORG_KEY);
     setToken("");
     setUser(null);
     setOrganizations([]);
+    setLocations([]);
     setCurrentOrgId(null);
+    setCurrentLocationId("all");
     setIsMenuOpen(false);
   }
 
+  function handleLocationUpdated(updatedLocation) {
+    setLocations((current) => current.map(
+      (item) => (item.id === updatedLocation.id ? updatedLocation : item)
+    ));
+  }
+
+  function toggleSidebar() {
+    setIsMenuOpen((current) => {
+      const next = !current;
+      if (window.innerWidth > 900) localStorage.setItem(SIDEBAR_KEY, String(next));
+      return next;
+    });
+  }
+
+  const hasAppShell = isAuthenticated && isAppRoute;
+
   return (
-    <div className={`layout ${isAuthenticated && isAppRoute ? "layout--app" : "layout--public"}`}>
-      {isAuthenticated && isAppRoute ? (
-        <AppHeader
-          currentOrg={currentOrg}
-          isMenuOpen={isMenuOpen}
-          onLogout={logout}
-          onShowCreateOrg={() => setShowCreateOrg(true)}
-          setIsMenuOpen={setIsMenuOpen}
-          user={user}
-        />
+    <div className={`layout ${hasAppShell ? "layout--app" : "layout--public"}${hasAppShell && !isMenuOpen ? " layout--sidebar-closed" : ""}`}>
+      {hasAppShell ? (
+        <AppHeader />
       ) : (
         <PublicHeader isAuthenticated={isAuthenticated} />
       )}
 
-      <main className={`app-main ${isAuthenticated && isAppRoute ? "app-main--app" : "app-main--public"}`}>
-        <Routes>
+      {hasAppShell && (
+        <AppSidebar
+          currentOrg={currentOrg}
+          currentOrgId={currentOrg?.id}
+          currentLocationId={currentLocationId}
+          isOpen={isMenuOpen}
+          locations={locations}
+          onClose={() => setIsMenuOpen(false)}
+          onLogout={logout}
+          onOrgChange={handleOrgChange}
+          onLocationChange={handleLocationChange}
+          onShowCreateOrg={() => setShowCreateOrg(true)}
+          onToggle={toggleSidebar}
+          organizations={organizations}
+          user={user}
+        />
+      )}
+
+      <main className={`app-main ${hasAppShell ? "app-main--app" : "app-main--public"}`}>
+        {token && !user ? (
+          <div className="route-loading" role="status">
+            Loading your workspace…
+          </div>
+        ) : (
+          <Routes>
           <Route
             path="/"
             element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <MarketingPage />}
@@ -149,12 +315,89 @@ export default function App() {
             element={
               isAuthenticated ? (
                 <Dashboard
+                  currentOrg={currentOrg}
+                  organizations={organizations}
+                  onShowCreateOrg={() => setShowCreateOrg(true)}
+                />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/roadmap"
+            element={
+              isAuthenticated ? (
+                <VotingBoardAdminPage
                   token={token}
                   currentOrg={currentOrg}
-                  currentOrgId={currentOrg?.id}
-                  organizations={organizations}
-                  onOrgChange={handleOrgChange}
-                  onShowCreateOrg={() => setShowCreateOrg(true)}
+                  currentLocation={currentLocation}
+                  locationId={selectedLocationId}
+                  locations={locations}
+                  canManage={canManageCurrentLocation}
+                />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/board"
+            element={
+              isAuthenticated ? (
+                <VotingBoardAdminPage
+                  token={token}
+                  currentOrg={currentOrg}
+                  currentLocation={currentLocation}
+                  locationId={selectedLocationId}
+                  locations={locations}
+                  canManage={canManageCurrentLocation}
+                />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/feedback"
+            element={
+              isAuthenticated ? (
+                <FeedbackReportsPage
+                  token={token}
+                  currentOrg={currentOrg}
+                  currentLocation={currentLocation}
+                  locationId={selectedLocationId}
+                  canManage={canManageCurrentLocation}
+                />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/reports"
+            element={
+              isAuthenticated ? (
+                <FeedbackReportsPage
+                  token={token}
+                  currentOrg={currentOrg}
+                  currentLocation={currentLocation}
+                  locationId={selectedLocationId}
+                  canManage={canManageCurrentLocation}
+                />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/feed"
+            element={
+              isAuthenticated ? (
+                <FeedPage
+                  token={token}
+                  orgId={currentOrg?.id}
+                  organizationName={currentOrg?.name}
                 />
               ) : (
                 <Navigate to="/auth?mode=login" replace />
@@ -165,7 +408,79 @@ export default function App() {
             path="/org/:id/settings"
             element={
               isAuthenticated ? (
-                <OrgSettingsPage token={token} user={user} />
+                <OrgSettingsPage
+                  token={token}
+                  user={user}
+                  section="general"
+                  currentLocation={currentLocation}
+                  onLocationUpdated={handleLocationUpdated}
+                />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/users"
+            element={
+              isAuthenticated ? (
+                <OrgSettingsPage token={token} user={user} section="users" locations={locations} />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/invites"
+            element={
+              isAuthenticated ? (
+                <Navigate to={`/org/${currentOrg?.id}/users`} replace />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/reviews"
+            element={
+              isAuthenticated ? (
+                <OrgSettingsPage
+                  token={token}
+                  user={user}
+                  section="reviews"
+                  currentLocation={currentLocation}
+                  canManageLocation={canManageCurrentLocation}
+                  onLocationUpdated={handleLocationUpdated}
+                />
+              ) : (
+                <Navigate to="/auth?mode=login" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/locations"
+            element={
+              !isAuthenticated ? (
+                <Navigate to="/auth?mode=login" replace />
+              ) : !currentOrg ? (
+                <div className="route-loading" role="status">Loading locations…</div>
+              ) : currentOrg.can_manage_organization ? (
+                  <LocationsPage
+                    token={token}
+                    orgId={currentOrg.id}
+                    locations={locations}
+                    onLocationsChanged={loadCurrentLocations}
+                  />
+              ) : (
+                <Navigate to="/dashboard" replace />
+              )
+            }
+          />
+          <Route
+            path="/org/:id/social"
+            element={
+              isAuthenticated ? (
+                <OrgSettingsPage token={token} user={user} section="social" />
               ) : (
                 <Navigate to="/auth?mode=login" replace />
               )
@@ -187,9 +502,12 @@ export default function App() {
           />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/feedback/:feedbackToken" element={<FeedbackPage />} />
+          <Route path="/roadmap/:feedbackToken" element={<VotingBoardPage />} />
+          <Route path="/board/:feedbackToken" element={<VotingBoardPage />} />
           <Route path="/reset-password" element={<ResetPasswordPage />} />
           <Route path="*" element={<Navigate to={isAuthenticated ? "/dashboard" : "/"} replace />} />
-        </Routes>
+          </Routes>
+        )}
       </main>
 
       {showCreateOrg && (
@@ -273,85 +591,328 @@ function PublicHeader({ isAuthenticated }) {
   );
 }
 
-function AppHeader({ currentOrg, isMenuOpen, onLogout, onShowCreateOrg, setIsMenuOpen, user }) {
+function AppHeader() {
   return (
     <header className="topbar topbar--app">
-      <img className="topbar-logo" src={LOGO_SRC} alt="five*" />
-
-      <div className="app-header-actions">
-        <TopbarSearch />
-
-        <div className="menu-wrap">
-          <button
-            type="button"
-            className="hamburger"
-            aria-label="Toggle menu"
-            aria-expanded={isMenuOpen}
-            onClick={() => setIsMenuOpen((value) => !value)}
+      <div className="app-journey" role="group" aria-label="Five Star journey">
+        {JOURNEY_MILESTONES.map((milestone, index) => (
+          <span
+            aria-label={`${milestone.title}. ${milestone.description}`}
+            aria-describedby={`journey-tooltip-${index}`}
+            className={`app-journey-star-wrap${index === 0 ? " app-journey-star-wrap--earned" : ""}`}
+            key={milestone.title}
+            role="img"
+            tabIndex="0"
           >
-            <span className="hamburger-bar" />
-            <span className="hamburger-bar" />
-            <span className="hamburger-bar" />
-          </button>
-
-          <div className={`menu-panel ${isMenuOpen ? "menu-panel--open" : ""}`}>
-            <div className="menu-section">
-              <p className="menu-kicker">Navigation</p>
-              <MenuLink to="/dashboard" label="Dashboard" setIsMenuOpen={setIsMenuOpen} />
-              {currentOrg && (
-                <MenuLink
-                  to={`/org/${currentOrg.id}/settings`}
-                  label="Org Settings"
-                  setIsMenuOpen={setIsMenuOpen}
-                />
-              )}
-            </div>
-            <div className="menu-divider" />
-            <div className="menu-section">
-              <p className="menu-kicker">Account</p>
-              <p className="menu-email">{user.email}</p>
-              <div style={{ marginTop: "0.8rem" }} />
-              <button
-                type="button"
-                className="menu-item"
-                onClick={() => {
-                  onShowCreateOrg();
-                  setIsMenuOpen(false);
-                }}
-              >
-                + New Organization
-              </button>
-              <button type="button" className="menu-item" onClick={onLogout}>
-                Log out
-              </button>
-            </div>
-          </div>
-        </div>
+            <span
+              className="app-journey-star"
+              aria-hidden="true"
+              style={{ "--journey-asterisk": `url("${ASTERISK_SRC}")` }}
+            />
+            <span className="app-journey-tooltip" id={`journey-tooltip-${index}`} role="tooltip">
+              <strong>{milestone.title}</strong>
+              <span>{milestone.description}</span>
+            </span>
+          </span>
+        ))}
       </div>
     </header>
   );
 }
 
-function MenuLink({ to, label, setIsMenuOpen }) {
-  const navigate = useNavigate();
+function SidebarIcon({ name }) {
+  const paths = {
+    overview: (
+      <>
+        <rect x="3" y="3" width="7" height="7" rx="1" />
+        <rect x="14" y="3" width="7" height="7" rx="1" />
+        <rect x="3" y="14" width="7" height="7" rx="1" />
+        <rect x="14" y="14" width="7" height="7" rx="1" />
+      </>
+    ),
+    board: (
+      <>
+        <path d="M9 18h6M10 22h4" />
+        <path d="M8.5 14.5A7 7 0 1 1 15.5 14.5c-.8.6-1.5 1.4-1.7 2.5h-3.6c-.2-1.1-.9-1.9-1.7-2.5Z" />
+      </>
+    ),
+    reports: (
+      <>
+        <path d="M4 19.5V4.5A2.5 2.5 0 0 1 6.5 2H20v17H6.5A2.5 2.5 0 0 0 4 21.5" />
+        <path d="M8 7h8M8 11h8M8 15h5" />
+      </>
+    ),
+    feed: (
+      <>
+        <rect x="3" y="3" width="18" height="18" rx="3" />
+        <circle cx="8.5" cy="8.5" r="1.5" />
+        <path d="m21 15-5-5L5 21" />
+      </>
+    ),
+    settings: (
+      <>
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1-2.8 2.8-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.6v.2h-4V21a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1L4.2 17l.1-.1a1.7 1.7 0 0 0 .3-1.9A1.7 1.7 0 0 0 3 14H2.8v-4H3a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9L4.2 7 7 4.2l.1.1a1.7 1.7 0 0 0 1.9.3A1.7 1.7 0 0 0 10 3V2.8h4V3a1.7 1.7 0 0 0 1 1.6 1.7 1.7 0 0 0 1.9-.3l.1-.1L19.8 7l-.1.1a1.7 1.7 0 0 0-.3 1.9 1.7 1.7 0 0 0 1.6 1h.2v4H21a1.7 1.7 0 0 0-1.6 1Z" />
+      </>
+    ),
+    users: (
+      <>
+        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M22 21v-2a4 4 0 0 0-3-3.9M16 3.1a4 4 0 0 1 0 7.8" />
+      </>
+    ),
+    invite: (
+      <>
+        <rect x="3" y="5" width="18" height="14" rx="2" />
+        <path d="m3 7 9 6 9-6M18 2v6M15 5h6" />
+      </>
+    ),
+    review: (
+      <path d="m12 2 3.1 6.3 6.9 1-5 4.8 1.2 6.9-6.2-3.3L5.8 21 7 14.1l-5-4.8 6.9-1L12 2Z" />
+    ),
+    social: (
+      <>
+        <circle cx="18" cy="5" r="3" />
+        <circle cx="6" cy="12" r="3" />
+        <circle cx="18" cy="19" r="3" />
+        <path d="m8.6 10.5 6.8-4M8.6 13.5l6.8 4" />
+      </>
+    ),
+    location: (
+      <>
+        <path d="M20 10c0 5-8 12-8 12S4 15 4 10a8 8 0 1 1 16 0Z" />
+        <circle cx="12" cy="10" r="2.5" />
+      </>
+    ),
+  };
   return (
-    <button
-      type="button"
-      className="menu-item"
-      onClick={() => {
-        setIsMenuOpen(false);
-        navigate(to);
-      }}
-    >
-      {label}
-    </button>
+    <svg className="sidebar-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      {paths[name]}
+    </svg>
   );
 }
 
-function Dashboard({ token, currentOrg, currentOrgId, organizations, onOrgChange, onShowCreateOrg }) {
-  const navigate = useNavigate();
-  const isAdmin = currentOrg?.role === "admin";
+function AppSidebar({
+  currentOrg,
+  currentOrgId,
+  currentLocationId,
+  isOpen,
+  locations,
+  onClose,
+  onLogout,
+  onLocationChange,
+  onOrgChange,
+  onShowCreateOrg,
+  onToggle,
+  organizations,
+  user,
+}) {
+  const [isWorkspaceOpen, setIsWorkspaceOpen] = useState(true);
+  const [isAdminOpen, setIsAdminOpen] = useState(true);
+  const closeOnMobile = () => {
+    if (window.innerWidth <= 900) onClose();
+  };
+  const orgBase = currentOrg ? `/org/${currentOrg.id}` : "";
+  const selectedLocation = locations.find(
+    (location) => location.id === Number(currentLocationId)
+  );
+  const canManageLocation = Boolean(currentOrg?.can_manage_organization) || Boolean(selectedLocation?.can_manage);
+  const workspaceItems = [
+    { to: "/dashboard", label: "Dashboard", icon: "overview", end: true },
+    { to: `${orgBase}/feedback`, label: "Feedback", icon: "reports", disabled: !currentOrg },
+    { to: `${orgBase}/roadmap`, label: "Roadmap", icon: "board", disabled: !currentOrg },
+    { to: `${orgBase}/feed`, label: "Feed", icon: "feed", disabled: !currentOrg },
+  ];
+  const adminItems = [
+    { to: `${orgBase}/settings`, label: "Settings", icon: "settings", disabled: !currentOrg },
+    { to: `${orgBase}/locations`, label: "Locations", icon: "location", disabled: !currentOrg },
+    { to: `${orgBase}/users`, label: "Users", icon: "users", disabled: !currentOrg },
+    { to: `${orgBase}/reviews`, label: "Public reviews", icon: "review", disabled: !currentOrg },
+    { to: `${orgBase}/social`, label: "Social accounts", icon: "social", disabled: !currentOrg },
+  ];
+  const locationManagerItems = [
+    { to: `${orgBase}/reviews`, label: "Public reviews", icon: "review", disabled: !currentOrg },
+  ];
 
+  function renderNavItems(items) {
+    return items.map((item) => item.disabled ? (
+      <span className="sidebar-nav-link sidebar-nav-link--disabled" key={item.label}>
+        <SidebarIcon name={item.icon} />
+        {item.label}
+      </span>
+    ) : (
+      <NavLink
+        className={({ isActive }) => `sidebar-nav-link${isActive ? " sidebar-nav-link--active" : ""}`}
+        end={item.end}
+        key={item.label}
+        onClick={closeOnMobile}
+        to={item.to}
+      >
+        <SidebarIcon name={item.icon} />
+        {item.label}
+      </NavLink>
+    ));
+  }
+
+  function renderRailItems(items) {
+    return items.map((item) => item.disabled ? (
+      <span
+        aria-label={item.label}
+        className="sidebar-rail-link sidebar-rail-link--disabled"
+        key={item.label}
+        title={item.label}
+      >
+        <SidebarIcon name={item.icon} />
+      </span>
+    ) : (
+      <NavLink
+        aria-label={item.label}
+        className={({ isActive }) => `sidebar-rail-link${isActive ? " sidebar-rail-link--active" : ""}`}
+        end={item.end}
+        key={item.label}
+        onClick={closeOnMobile}
+        title={item.label}
+        to={item.to}
+      >
+        <SidebarIcon name={item.icon} />
+      </NavLink>
+    ));
+  }
+
+  return (
+    <>
+      {!isOpen && (
+        <aside className="app-sidebar-rail" aria-label="Collapsed sidebar">
+          <button
+            type="button"
+            className="sidebar-panel-toggle"
+            aria-label="Open sidebar"
+            aria-expanded="false"
+            onClick={(event) => {
+              event.currentTarget.blur();
+              onToggle();
+            }}
+          >
+            <span className="hamburger-bar" />
+            <span className="hamburger-bar" />
+            <span className="hamburger-bar" />
+          </button>
+          <nav className="sidebar-rail-nav" aria-label="Workspace navigation">
+            {renderRailItems(workspaceItems)}
+          </nav>
+          {canManageLocation && (
+            <nav className="sidebar-rail-nav sidebar-rail-nav--admin" aria-label="Administration navigation">
+              {renderRailItems(currentOrg?.can_manage_organization ? adminItems : locationManagerItems)}
+            </nav>
+          )}
+        </aside>
+      )}
+      <aside
+        aria-hidden={!isOpen}
+        className={`app-sidebar${isOpen ? " app-sidebar--open" : ""}`}
+        inert={!isOpen ? true : undefined}
+      >
+        <div className="sidebar-header">
+          <Link className="sidebar-organization-name" to="/dashboard" title={currentOrg?.name || "Organization"}>
+            {currentOrg?.name || "Organization"}
+          </Link>
+          <button
+            type="button"
+            className="sidebar-panel-toggle"
+            aria-label="Collapse sidebar"
+            aria-expanded="true"
+            onClick={(event) => {
+              event.currentTarget.blur();
+              onToggle();
+            }}
+          >
+            <span className="hamburger-bar" />
+            <span className="hamburger-bar" />
+            <span className="hamburger-bar" />
+          </button>
+        </div>
+
+        <div className="sidebar-organization">
+          <OrganizationSwitcher
+            organizations={organizations}
+            currentOrgId={currentOrgId}
+            onOrgChange={onOrgChange}
+            onCreateOrganization={() => {
+              onShowCreateOrg();
+              closeOnMobile();
+            }}
+          />
+          <LocationSwitcher
+            canViewAll={Boolean(currentOrg?.can_view_all_locations)}
+            currentLocationId={currentLocationId}
+            locations={locations}
+            onLocationChange={onLocationChange}
+          />
+        </div>
+
+        <nav className="sidebar-nav" aria-label="Organization navigation">
+          <button
+            type="button"
+            className="sidebar-section-toggle"
+            aria-expanded={isWorkspaceOpen}
+            onClick={() => setIsWorkspaceOpen((current) => !current)}
+          >
+            <span>Workspace</span>
+            <span aria-hidden="true">{isWorkspaceOpen ? "−" : "+"}</span>
+          </button>
+          {isWorkspaceOpen && <div className="sidebar-section-links">{renderNavItems(workspaceItems)}</div>}
+        </nav>
+
+        {canManageLocation && (
+          <nav
+            className="sidebar-nav sidebar-nav--admin"
+            aria-label={currentOrg?.can_manage_organization ? "Administration navigation" : "Location management navigation"}
+          >
+            <button
+              type="button"
+              className="sidebar-section-toggle"
+              aria-expanded={isAdminOpen}
+              onClick={() => setIsAdminOpen((current) => !current)}
+            >
+              <span>{currentOrg?.can_manage_organization ? "Admin" : "Location"}</span>
+              <span aria-hidden="true">{isAdminOpen ? "−" : "+"}</span>
+            </button>
+            {isAdminOpen && (
+              <div className="sidebar-section-links">
+                {renderNavItems(currentOrg?.can_manage_organization ? adminItems : locationManagerItems)}
+              </div>
+            )}
+          </nav>
+        )}
+
+        <div className="sidebar-footer">
+          <div className="sidebar-account">
+            <span className="sidebar-avatar">{user?.email?.charAt(0).toUpperCase()}</span>
+            <div className="sidebar-account-copy">
+              <strong>{user?.email}</strong>
+              <span>{accessRoleLabel(currentOrg?.role)}</span>
+            </div>
+            <button type="button" className="sidebar-logout" onClick={onLogout} aria-label="Log out" title="Log out">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M10 17l5-5-5-5M15 12H3" />
+                <path d="M14 3h5a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-5" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </aside>
+      <button
+        type="button"
+        className={`sidebar-backdrop${isOpen ? " sidebar-backdrop--visible" : ""}`}
+        onClick={onClose}
+        aria-label="Close sidebar"
+      />
+    </>
+  );
+}
+
+function Dashboard({ currentOrg, organizations, onShowCreateOrg }) {
   if (!organizations.length) {
     return (
       <div className="dashboard-empty">
@@ -366,25 +927,79 @@ function Dashboard({ token, currentOrg, currentOrgId, organizations, onOrgChange
 
   return (
     <div className="dashboard">
-      <div className="dashboard-header">
-        <h2 className="dashboard-title">{currentOrg?.name}</h2>
-        <div className="dashboard-actions">
-          <OrganizationSwitcher
-            organizations={organizations}
-            currentOrgId={currentOrgId}
-            onOrgChange={onOrgChange}
-          />
-          <button
-            type="button"
-            className="btn btn--ghost btn--sm"
-            onClick={() => navigate(`/org/${currentOrg?.id}/settings`)}
-          >
-            Org Settings
-          </button>
-        </div>
+      <div className="dashboard-welcome">
+        <p className="dashboard-kicker">Dashboard</p>
+        <h1>{currentOrg?.name}</h1>
+        <p>Customer feedback, roadmap priorities, and social publishing for your organization.</p>
       </div>
 
-      {isAdmin && currentOrg && <DigestManager token={token} orgId={currentOrg.id} isAdmin={true} />}
+      <section className="dashboard-widget-grid" aria-label="Workspace widgets">
+        <DashboardWidget
+          description="Publish what you’re working on and see what matters most to customers."
+          icon={<SidebarIcon name="board" />}
+          title="Roadmap"
+          to={`/org/${currentOrg?.id}/roadmap`}
+        />
+        <DashboardWidget
+          description="Review submissions and turn customer feedback into clear, shareable reports."
+          icon={<SidebarIcon name="reports" />}
+          title="Feedback"
+          to={`/org/${currentOrg?.id}/feedback`}
+        />
+        <DashboardWidget
+          description="Draft once, tailor each platform version, then publish or schedule across connected channels."
+          icon={<SidebarIcon name="feed" />}
+          title="Feed"
+          to={`/org/${currentOrg?.id}/feed`}
+        />
+        {currentOrg?.can_manage_organization && (
+          <DashboardWidget
+            description="Manage organization details, public links, users, reviews, and connected accounts."
+            icon={<SidebarIcon name="settings" />}
+            title="Settings"
+            to={`/org/${currentOrg?.id}/settings`}
+          />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function VotingBoardAdminPage({
+  token,
+  currentOrg,
+  currentLocation,
+  locationId,
+  locations,
+  canManage,
+}) {
+  if (!currentOrg) return <div className="owner-feature-page"><p>Loading organization…</p></div>;
+  return (
+    <div className="owner-feature-page">
+      <InitiativesManager
+        token={token}
+        orgId={currentOrg.id}
+        isAdmin={canManage}
+        locationId={locationId}
+        locations={locations}
+        publicBoardUrl={currentLocation ? `/roadmap/${currentLocation.feedback_token}` : null}
+      />
+    </div>
+  );
+}
+
+function FeedbackReportsPage({ token, currentOrg, currentLocation, locationId, canManage }) {
+  if (!currentOrg) return <div className="owner-feature-page"><p>Loading organization…</p></div>;
+  return (
+    <div className="owner-feature-page">
+      <DigestManager
+        key={`${currentOrg.id}-${locationId || "all"}`}
+        token={token}
+        orgId={currentOrg.id}
+        locationId={locationId}
+        isAdmin={canManage}
+        timezone={currentLocation?.timezone}
+      />
     </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -105,6 +105,111 @@ export async function deleteOrganization(token, orgId) {
   });
 }
 
+// Social connections
+
+export async function listSocialConnections(token, orgId) {
+  return request(`/organizations/${orgId}/social-connections`, {
+    headers: authHeaders(token),
+  });
+}
+
+export async function beginSocialConnection(token, orgId, provider) {
+  return request(`/organizations/${orgId}/social-connections/${provider}/authorize`, {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+}
+
+export async function disconnectSocialConnection(token, orgId, provider) {
+  return request(`/organizations/${orgId}/social-connections/${provider}`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+}
+
+export async function getFacebookPageOptions(token, orgId, setupToken) {
+  return request(
+    `/organizations/${orgId}/social-connections/facebook/options?setup=${encodeURIComponent(setupToken)}`,
+    { headers: authHeaders(token) }
+  );
+}
+
+export async function completeFacebookConnection(token, orgId, setupToken, pageId) {
+  return request(`/organizations/${orgId}/social-connections/facebook/complete`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ setup_token: setupToken, page_id: pageId }),
+  });
+}
+
+export async function listSocialPosts(token, orgId, limit = 25) {
+  return request(`/organizations/${orgId}/social-posts?limit=${limit}`, {
+    headers: authHeaders(token),
+  });
+}
+
+export async function generateSocialDrafts(token, orgId, masterCaption) {
+  return request(`/organizations/${orgId}/social-posts/drafts/generate`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ master_caption: masterCaption }),
+  });
+}
+
+export async function createSocialPost(token, orgId, data) {
+  return request(`/organizations/${orgId}/social-posts`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify(data),
+  });
+}
+
+export async function publishSocialPost(token, orgId, postId) {
+  return request(`/organizations/${orgId}/social-posts/${postId}/publish`, {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+}
+
+// Locations
+
+export async function listLocations(token, orgId) {
+  return request(`/organizations/${orgId}/locations`, {
+    headers: authHeaders(token),
+  });
+}
+
+export async function createLocation(token, orgId, data) {
+  return request(`/organizations/${orgId}/locations`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateLocation(token, orgId, locationId, data) {
+  return request(`/organizations/${orgId}/locations/${locationId}`, {
+    method: "PATCH",
+    headers: authHeaders(token),
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteLocation(token, orgId, locationId) {
+  return request(`/organizations/${orgId}/locations/${locationId}`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+}
+
+export async function updateLocationReviewLinks(token, orgId, locationId, reviewLinks) {
+  return request(`/organizations/${orgId}/locations/${locationId}/review-links`, {
+    method: "PATCH",
+    headers: authHeaders(token),
+    body: JSON.stringify({ review_links: reviewLinks }),
+  });
+}
+
 // Members
 
 export async function listMembers(token, orgId) {
@@ -128,13 +233,25 @@ export async function removeMember(token, orgId, userId) {
   });
 }
 
+export async function updateMemberLocationAssignments(token, orgId, userId, assignments) {
+  return request(`/organizations/${orgId}/members/${userId}/locations`, {
+    method: "PUT",
+    headers: authHeaders(token),
+    body: JSON.stringify({ assignments }),
+  });
+}
+
 // Invites
 
-export async function createInvite(token, orgId, role, expiresInHours = 168) {
+export async function createInvite(token, orgId, role, expiresInHours = 168, locationId = null) {
   return request(`/organizations/${orgId}/invites`, {
     method: "POST",
     headers: authHeaders(token),
-    body: JSON.stringify({ role, expires_in_hours: expiresInHours }),
+    body: JSON.stringify({
+      role,
+      expires_in_hours: expiresInHours,
+      location_id: locationId,
+    }),
   });
 }
 
@@ -187,32 +304,88 @@ export async function polishReview(feedbackToken, content, style) {
 }
 
 // Future: Admin feedback list
-export async function listOrganizationFeedback(token, orgId) {
-  return request(`/organizations/${orgId}/feedback`, {
+export async function listOrganizationFeedback(token, orgId, locationId = null) {
+  const params = new URLSearchParams();
+  if (locationId) params.set("location_id", locationId);
+  return request(`/organizations/${orgId}/feedback${params.size ? `?${params}` : ""}`, {
     headers: authHeaders(token),
+  });
+}
+
+// Organization voting board
+
+export async function listOrganizationInitiatives(token, orgId, locationId = null) {
+  const params = new URLSearchParams();
+  if (locationId) params.set("location_id", locationId);
+  return request(`/organizations/${orgId}/initiatives${params.size ? `?${params}` : ""}`, {
+    headers: authHeaders(token),
+  });
+}
+
+export async function createOrganizationInitiative(token, orgId, data) {
+  return request(`/organizations/${orgId}/initiatives`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateOrganizationInitiative(token, orgId, initiativeId, data) {
+  return request(`/organizations/${orgId}/initiatives/${initiativeId}`, {
+    method: "PATCH",
+    headers: authHeaders(token),
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteOrganizationInitiative(token, orgId, initiativeId) {
+  return request(`/organizations/${orgId}/initiatives/${initiativeId}`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+}
+
+export async function getPublicBoard(feedbackToken, { query = "", status = "", sort = "top", visitorId } = {}) {
+  const params = new URLSearchParams({ sort });
+  if (query.trim()) params.set("q", query.trim());
+  if (status) params.set("status", status);
+  return request(`/api/boards/${feedbackToken}?${params.toString()}`, {
+    headers: visitorId ? { "X-Visitor-ID": visitorId } : {},
+  });
+}
+
+export async function updatePublicInitiativeVote(feedbackToken, initiativeId, value, visitorId) {
+  return request(`/api/boards/${feedbackToken}/initiatives/${initiativeId}/vote`, {
+    method: "PUT",
+    headers: { "X-Visitor-ID": visitorId },
+    body: JSON.stringify({ value }),
   });
 }
 
 // Feedback Stats
 
-export async function getFeedbackStats(token, orgId, days = 7) {
-  return request(`/organizations/${orgId}/feedback/stats?days=${days}`, {
+export async function getFeedbackStats(token, orgId, days = 7, locationId = null) {
+  const params = new URLSearchParams({ days: String(days) });
+  if (locationId) params.set("location_id", locationId);
+  return request(`/organizations/${orgId}/feedback/stats?${params}`, {
     headers: authHeaders(token),
   });
 }
 
 // Digests
 
-export async function generateDigest(token, orgId, periodStart, periodEnd) {
+export async function generateDigest(token, orgId, periodStart, periodEnd, locationId = null) {
   return request(`/organizations/${orgId}/digests/generate`, {
     method: "POST",
     headers: authHeaders(token),
-    body: JSON.stringify({ period_start: periodStart, period_end: periodEnd }),
+    body: JSON.stringify({ period_start: periodStart, period_end: periodEnd, location_id: locationId }),
   });
 }
 
-export async function listDigests(token, orgId) {
-  return request(`/organizations/${orgId}/digests`, {
+export async function listDigests(token, orgId, locationId = null) {
+  const params = new URLSearchParams();
+  if (locationId) params.set("location_id", locationId);
+  return request(`/organizations/${orgId}/digests${params.size ? `?${params}` : ""}`, {
     headers: authHeaders(token),
   });
 }

--- a/frontend/src/components/AuthPage.jsx
+++ b/frontend/src/components/AuthPage.jsx
@@ -81,7 +81,7 @@ export default function AuthPage({ loadOrganizations, onAuthenticated }) {
           </div>
           <div className="auth-highlight">
             <h2>Actionable insight</h2>
-            <p>Digest summaries help you turn comments into practical next steps.</p>
+            <p>Feedback reports help you turn comments into practical next steps.</p>
           </div>
         </div>
       </section>

--- a/frontend/src/components/DashboardWidget.jsx
+++ b/frontend/src/components/DashboardWidget.jsx
@@ -1,0 +1,15 @@
+import { Link } from "react-router-dom";
+
+export default function DashboardWidget({ children, description, icon, title, to }) {
+  return (
+    <Link className="dashboard-widget" to={to}>
+      <span className="dashboard-widget-icon">{icon}</span>
+      <div className="dashboard-widget-copy">
+        <h2>{title}</h2>
+        <p>{description}</p>
+        {children}
+      </div>
+      <span className="dashboard-widget-arrow" aria-hidden="true">→</span>
+    </Link>
+  );
+}

--- a/frontend/src/components/DigestManager.jsx
+++ b/frontend/src/components/DigestManager.jsx
@@ -19,14 +19,25 @@ const HORIZONS = [
   { label: "Last year", days: 365 },
 ];
 
-function daysAgoIso(n) {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 10);
+function dateInTimezoneIso(daysAgo, timezone) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]));
+  const date = new Date(Date.UTC(Number(values.year), Number(values.month) - 1, Number(values.day)));
+  date.setUTCDate(date.getUTCDate() - daysAgo);
+  return date.toISOString().slice(0, 10);
 }
 
-function todayIso() {
-  return new Date().toISOString().slice(0, 10);
+function daysAgoIso(n, timezone) {
+  return dateInTimezoneIso(n, timezone);
+}
+
+function todayIso(timezone) {
+  return dateInTimezoneIso(0, timezone);
 }
 
 // ─── ListEditor ─────────────────────────────────────────────────────────────
@@ -140,7 +151,7 @@ function DigestEditor({ digest, token, orgId, onSaved, onPublished, onCancel }) 
   }
 
   async function handlePublish() {
-    if (!window.confirm("Share this digest with all org members? This cannot be undone.")) return;
+    if (!window.confirm("Share this report with all organization members? This cannot be undone.")) return;
     setIsPublishing(true);
     setError("");
     try {
@@ -206,7 +217,7 @@ function DigestEditor({ digest, token, orgId, onSaved, onPublished, onCancel }) 
 
 // ─── DigestCard ───────────────────────────────────────────────────────────────
 
-function DigestCard({ digest, token, orgId, isAdmin, onUpdate, onDelete }) {
+function DigestCard({ digest, token, orgId, isAdmin, onUpdate, onDelete, showLocation }) {
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -214,7 +225,7 @@ function DigestCard({ digest, token, orgId, isAdmin, onUpdate, onDelete }) {
   const isDraft = digest.status === "draft";
 
   async function handleDelete() {
-    if (!window.confirm("Delete this digest? This cannot be undone.")) return;
+    if (!window.confirm("Delete this report? This cannot be undone.")) return;
     setIsDeleting(true);
     try {
       await deleteDigest(token, orgId, digest.id);
@@ -265,6 +276,9 @@ function DigestCard({ digest, token, orgId, isAdmin, onUpdate, onDelete }) {
           >
             {isDraft ? "Draft" : "Published"}
           </span>
+          {showLocation && (
+            <span className="initiative-location-badge">{digest.location_name}</span>
+          )}
           <span style={{ fontSize: "0.95rem", fontWeight: 700, color: "var(--color-ink)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {digest.period_start === digest.period_end
               ? digest.period_start
@@ -321,7 +335,7 @@ function DigestCard({ digest, token, orgId, isAdmin, onUpdate, onDelete }) {
 
 // ─── DigestManager (main export) ─────────────────────────────────────────────
 
-export default function DigestManager({ token, orgId, isAdmin }) {
+export default function DigestManager({ token, orgId, locationId, isAdmin, timezone }) {
   const [selectedHorizon, setSelectedHorizon] = useState(HORIZONS[2]); // Last 7 days
   const [chartData, setChartData] = useState([]);
   const [chartLoading, setChartLoading] = useState(false);
@@ -332,17 +346,17 @@ export default function DigestManager({ token, orgId, isAdmin }) {
   // Load chart data whenever horizon changes
   useEffect(() => {
     loadStats();
-  }, [selectedHorizon]);
+  }, [selectedHorizon, locationId]);
 
   // Load digests on mount
   useEffect(() => {
     loadDigests();
-  }, []);
+  }, [locationId]);
 
   async function loadStats() {
     setChartLoading(true);
     try {
-      const result = await getFeedbackStats(token, orgId, selectedHorizon.days);
+      const result = await getFeedbackStats(token, orgId, selectedHorizon.days, locationId);
       setChartData(result.data);
     } catch {
       // silently fail chart — non-critical
@@ -353,7 +367,7 @@ export default function DigestManager({ token, orgId, isAdmin }) {
 
   async function loadDigests() {
     try {
-      const data = await listDigests(token, orgId);
+      const data = await listDigests(token, orgId, locationId);
       setDigests(data);
     } catch {
       // silently fail
@@ -364,9 +378,9 @@ export default function DigestManager({ token, orgId, isAdmin }) {
     setIsGenerating(true);
     setGenerateError("");
     try {
-      const periodEnd = todayIso();
-      const periodStart = daysAgoIso(selectedHorizon.days - 1);
-      const newDigest = await generateDigest(token, orgId, periodStart, periodEnd);
+      const periodEnd = todayIso(timezone);
+      const periodStart = daysAgoIso(selectedHorizon.days - 1, timezone);
+      const newDigest = await generateDigest(token, orgId, periodStart, periodEnd, locationId);
       setDigests((prev) => [newDigest, ...prev]);
     } catch (err) {
       setGenerateError(err.message);
@@ -387,9 +401,9 @@ export default function DigestManager({ token, orgId, isAdmin }) {
 
   return (
     <div className="settings-section">
-      <h3 className="settings-heading">Feedback Digests</h3>
+      <h3 className="settings-heading">Feedback reports</h3>
       <p className="settings-meta">
-        Summarize feedback into a structured digest and share it with your organization.
+        Summarize feedback into a structured report and share it with your organization.
       </p>
 
       {/* Horizon selector - pills on desktop, dropdown on mobile */}
@@ -455,14 +469,19 @@ export default function DigestManager({ token, orgId, isAdmin }) {
       {/* Generate button */}
       {isAdmin && (
         <div style={{ marginBottom: "1.5rem" }}>
+          {!locationId && (
+            <p className="message message--info" style={{ marginBottom: "0.5rem" }}>
+              Select one location to generate a report. The chart and existing reports can still roll up every location.
+            </p>
+          )}
           {generateError && <p className="message message--error" style={{ marginBottom: "0.5rem" }}>{generateError}</p>}
           <button
             type="button"
             className="btn btn--primary"
             onClick={handleGenerate}
-            disabled={isGenerating}
+            disabled={isGenerating || !locationId}
           >
-            {isGenerating ? "Generating digest…" : `Generate Digest for ${selectedHorizon.label.toLowerCase()}`}
+            {isGenerating ? "Generating report…" : `Generate Report for ${selectedHorizon.label.toLowerCase()}`}
           </button>
           {isGenerating && (
             <p className="settings-meta" style={{ marginTop: "0.4rem" }}>
@@ -476,7 +495,7 @@ export default function DigestManager({ token, orgId, isAdmin }) {
       {digests.length > 0 ? (
         <div style={{ display: "grid", gap: "0.6rem" }}>
           <p style={{ margin: "0 0 0.4rem", fontWeight: 700, fontSize: "0.88rem", color: "var(--color-neutral-strong)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
-            {digests.length} digest{digests.length !== 1 ? "s" : ""}
+            {digests.length} report{digests.length !== 1 ? "s" : ""}
           </p>
           {digests.map((d) => (
             <DigestCard
@@ -487,11 +506,12 @@ export default function DigestManager({ token, orgId, isAdmin }) {
               isAdmin={isAdmin}
               onUpdate={handleUpdate}
               onDelete={handleDelete}
+              showLocation={!locationId}
             />
           ))}
         </div>
       ) : (
-        <p className="settings-meta">No digests yet. Generate one above to get started.</p>
+        <p className="settings-meta">No reports yet. Generate one above to get started.</p>
       )}
     </div>
   );

--- a/frontend/src/components/DigestsPage.jsx
+++ b/frontend/src/components/DigestsPage.jsx
@@ -165,7 +165,7 @@ export default function DigestsPage({ token, orgId: orgIdProp }) {
       </button>
 
       <div className="settings-section">
-        <h2 className="settings-title">Org Digests</h2>
+        <h2 className="settings-title">Organization reports</h2>
         <p className="settings-meta">
           Published feedback summaries shared by your organization&apos;s admins.
         </p>
@@ -175,7 +175,7 @@ export default function DigestsPage({ token, orgId: orgIdProp }) {
       {error && <p className="message message--error">{error}</p>}
 
       {!loading && !error && digests.length === 0 && (
-        <p className="settings-meta">No digests have been published yet.</p>
+        <p className="settings-meta">No reports have been published yet.</p>
       )}
 
       {digests.length > 0 && (

--- a/frontend/src/components/FeedPage.jsx
+++ b/frontend/src/components/FeedPage.jsx
@@ -1,0 +1,511 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  createSocialPost,
+  generateSocialDrafts,
+  listSocialConnections,
+  listSocialPosts,
+  publishSocialPost,
+} from "../api";
+
+const CHANNELS = [
+  { id: "facebook", label: "Facebook", prompt: "Write a friendly community update." },
+  { id: "instagram", label: "Instagram", prompt: "Write a visual-first caption with a few relevant hashtags." },
+  { id: "tiktok", label: "TikTok", prompt: "Write a short, energetic hook and call to action." },
+];
+
+function platformDrafts(source) {
+  const text = source.trim();
+  return {
+    facebook: text,
+    instagram: `${text}\n\n#FiveStar #CustomerFeedback`,
+    tiktok: `${text}\n\nTell us what you think 👇`,
+  };
+}
+
+function postStatusLabel(status) {
+  return {
+    draft: "Draft",
+    scheduled: "Scheduled",
+    publishing: "Publishing",
+    published: "Published",
+    partial_failure: "Partially published",
+    failed: "Failed",
+  }[status] || status;
+}
+
+export default function FeedPage({ token, orgId, organizationName }) {
+  const [message, setMessage] = useState("");
+  const [drafts, setDrafts] = useState({});
+  const [activeChannel, setActiveChannel] = useState(CHANNELS[0].id);
+  const [publishMode, setPublishMode] = useState("now");
+  const [channels, setChannels] = useState([]);
+  const [imageNames, setImageNames] = useState([]);
+  const [mediaUrl, setMediaUrl] = useState("");
+  const [scheduleDate, setScheduleDate] = useState("");
+  const [scheduleTime, setScheduleTime] = useState("");
+  const [connections, setConnections] = useState([]);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [wordsmithing, setWordsmithing] = useState(false);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+
+  const activePlatform = CHANNELS.find((channel) => channel.id === activeChannel) || CHANNELS[0];
+  const activeDraft = drafts[activeChannel] || "";
+  const connectedProviders = useMemo(
+    () => new Set(
+      connections
+        .filter((connection) => (
+          connection.connected
+          && connection.status === "connected"
+          && connection.publishing_enabled
+        ))
+        .map((connection) => connection.provider)
+    ),
+    [connections]
+  );
+  const canDraft = Boolean(message.trim());
+  const canPreview = useMemo(
+    () => Boolean(Object.values(drafts).some((draft) => draft.trim()) || imageNames.length || mediaUrl.trim()),
+    [drafts, imageNames, mediaUrl]
+  );
+  const scheduledPosts = posts.filter((post) => post.status === "scheduled");
+  const savedDrafts = posts.filter((post) => post.status === "draft");
+  const selectedInstagramWithoutMedia = channels.includes("instagram") && !mediaUrl.trim();
+  const canSave = (
+    channels.length > 0
+    && channels.every((channel) => drafts[channel]?.trim())
+    && !selectedInstagramWithoutMedia
+  );
+  const canSubmit = canSave && (
+    publishMode !== "schedule" || (scheduleDate && scheduleTime)
+  );
+
+  async function loadPublishingData() {
+    if (!token || !orgId) return;
+    setLoading(true);
+    setError("");
+    try {
+      const [connectionData, postData] = await Promise.all([
+        listSocialConnections(token, orgId),
+        listSocialPosts(token, orgId),
+      ]);
+      setConnections(connectionData);
+      setPosts(postData);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadPublishingData();
+  }, [token, orgId]);
+
+  function toggleChannel(channel) {
+    if (!connectedProviders.has(channel)) {
+      setNotice(`Connect ${CHANNELS.find((item) => item.id === channel)?.label} before selecting it.`);
+      return;
+    }
+    setNotice("");
+    setChannels((current) => (
+      current.includes(channel)
+        ? current.filter((item) => item !== channel)
+        : [...current, channel]
+    ));
+  }
+
+  async function generatePlatformDrafts() {
+    if (!canDraft) return;
+    setWordsmithing(true);
+    setError("");
+    setNotice("");
+    try {
+      const generated = await generateSocialDrafts(token, orgId, message.trim());
+      setDrafts(generated);
+      setNotice(
+        connectedProviders.size
+          ? "AI drafts are ready. Review every version before publishing."
+          : "AI drafts are ready. Connect at least one destination before publishing."
+      );
+    } catch {
+      setDrafts(platformDrafts(message));
+      setNotice("AI drafting was unavailable, so starter versions were created instead.");
+    } finally {
+      setChannels(CHANNELS.filter((channel) => connectedProviders.has(channel.id)).map((channel) => channel.id));
+      setWordsmithing(false);
+    }
+  }
+
+  function updateActiveDraft(value) {
+    setDrafts((current) => ({ ...current, [activeChannel]: value }));
+  }
+
+  function resetActiveDraft() {
+    setDrafts((current) => ({ ...current, [activeChannel]: message }));
+  }
+
+  async function submitPost(submitMode = publishMode) {
+    const validForMode = submitMode === "draft" ? canSave : canSubmit;
+    if (!validForMode || working) return;
+    setWorking(true);
+    setError("");
+    setNotice("");
+    try {
+      let scheduledAt = null;
+      if (submitMode === "schedule") {
+        scheduledAt = new Date(`${scheduleDate}T${scheduleTime}`).toISOString();
+      }
+      const created = await createSocialPost(token, orgId, {
+        master_caption: message.trim(),
+        targets: channels.map((provider) => ({
+          provider,
+          content: drafts[provider].trim(),
+        })),
+        media_urls: mediaUrl.trim() ? [mediaUrl.trim()] : [],
+        scheduled_at: scheduledAt,
+      });
+      const completed = submitMode === "now"
+        ? await publishSocialPost(token, orgId, created.id)
+        : created;
+      setPosts((current) => [completed, ...current.filter((post) => post.id !== completed.id)]);
+      setNotice(
+        submitMode === "draft"
+          ? "Draft saved."
+          : submitMode === "schedule"
+            ? "Post scheduled."
+          : completed.status === "published"
+            ? "Post published."
+            : completed.status === "partial_failure"
+              ? "Some destinations published; review the errors below."
+              : "Publishing failed. Review the destination errors below."
+      );
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <div className="feed-page">
+      <header className="portal-page-heading">
+        <p className="dashboard-kicker">Publishing</p>
+        <h1>Feed</h1>
+        <p>Start with one idea, shape it for each platform, then publish or schedule the versions you want.</p>
+      </header>
+
+      {error && <p className="message message--error">{error}</p>}
+      {notice && <p className="message message--success">{notice}</p>}
+
+      <div className="feed-layout">
+        <section className="portal-card feed-workspace">
+          <div className="feed-workspace-heading">
+            <div>
+              <span className="status-pill status-pill--connected">Draft workspace</span>
+              <h2>Create a post</h2>
+              <p>Write the source caption once. Platform drafts can be edited independently.</p>
+            </div>
+            <span className="feed-org-label">{organizationName}</span>
+          </div>
+
+          <div className="feed-master-section">
+            <label className="field-label" htmlFor="feed-message">Master caption</label>
+            <textarea
+              className="field-textarea feed-message"
+              id="feed-message"
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder="Share the idea, announcement, or update you want to turn into platform posts…"
+              rows="6"
+              value={message}
+            />
+
+            <div className="feed-media-fields">
+              <label className="feed-media-picker" htmlFor="feed-media">
+                <span className="feed-media-icon" aria-hidden="true">＋</span>
+                <span>
+                  <strong>Choose local images</strong>
+                  <small>Preview only until managed media storage is enabled</small>
+                </span>
+                <input
+                  id="feed-media"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  multiple
+                  onChange={(event) => setImageNames(Array.from(event.target.files || []).map((file) => file.name))}
+                />
+              </label>
+              <label className="feed-media-url">
+                <span className="field-label">Hosted image URL</span>
+                <input
+                  className="field-input"
+                  onChange={(event) => setMediaUrl(event.target.value)}
+                  placeholder="https://images.example.com/post.jpg"
+                  type="url"
+                  value={mediaUrl}
+                />
+                <small>Required for Instagram publishing in this integration pass.</small>
+              </label>
+            </div>
+
+            {imageNames.length > 0 && (
+              <div className="feed-file-list" aria-label="Selected images">
+                {imageNames.map((name) => <span key={name}>{name}</span>)}
+              </div>
+            )}
+
+            <div className="feed-wordsmith-bar">
+              <div>
+                <strong>AI wordsmith</strong>
+                <span>Adapt this idea for every platform, then review each version.</span>
+              </div>
+              <button className="btn btn--ghost btn--sm" disabled={!canDraft || wordsmithing} onClick={generatePlatformDrafts} type="button">
+                {wordsmithing ? "Wordsmithing…" : "Wordsmith with AI"}
+              </button>
+            </div>
+          </div>
+
+          <section className="feed-drafts-section" aria-labelledby="feed-drafts-heading">
+            <div className="feed-section-heading">
+              <div>
+                <h3 id="feed-drafts-heading">Platform drafts</h3>
+                <p>Edit each version and choose one or more connected platforms.</p>
+              </div>
+              <span className="feed-selection-count">{channels.length} selected</span>
+            </div>
+
+            <div className="feed-draft-tabs" role="tablist" aria-label="Platform drafts">
+              {CHANNELS.map((channel) => {
+                const isConnected = connectedProviders.has(channel.id);
+                return (
+                  <button
+                    aria-selected={activeChannel === channel.id}
+                    className={`feed-draft-tab${activeChannel === channel.id ? " feed-draft-tab--active" : ""}${isConnected ? "" : " feed-draft-tab--unavailable"}`}
+                    key={channel.id}
+                    onClick={() => setActiveChannel(channel.id)}
+                    role="tab"
+                    type="button"
+                  >
+                    <span className="feed-draft-tab-mark" aria-hidden="true">{channel.label.slice(0, 1)}</span>
+                    <span>{channel.label}</span>
+                    <span className={`feed-draft-tab-check${channels.includes(channel.id) ? " feed-draft-tab-check--selected" : ""}`} aria-hidden="true">
+                      {channels.includes(channel.id) ? "✓" : isConnected ? "+" : "—"}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="feed-draft-panel" role="tabpanel">
+              <div className="feed-draft-panel-heading">
+                <div>
+                  <h4>{activePlatform.label} draft</h4>
+                  <p>{activePlatform.prompt}</p>
+                </div>
+                <label className="feed-draft-include">
+                  <input
+                    checked={channels.includes(activeChannel)}
+                    disabled={!connectedProviders.has(activeChannel)}
+                    onChange={() => toggleChannel(activeChannel)}
+                    type="checkbox"
+                  />
+                  {connectedProviders.has(activeChannel) ? "Include in publish" : "Not connected"}
+                </label>
+              </div>
+              <textarea
+                aria-label={`${activePlatform.label} draft`}
+                className="field-textarea feed-platform-draft"
+                onChange={(event) => updateActiveDraft(event.target.value)}
+                placeholder={`Your ${activePlatform.label} draft will appear here…`}
+                rows="6"
+                value={activeDraft}
+              />
+              <div className="feed-draft-panel-footer">
+                <span>{activeDraft.length} characters</span>
+                <button className="btn btn--ghost btn--sm" disabled={!message.trim()} onClick={resetActiveDraft} type="button">
+                  Use master caption
+                </button>
+              </div>
+            </div>
+          </section>
+        </section>
+
+        <section className="portal-card feed-publish-card">
+          <div className="feed-section-heading">
+            <div>
+              <h3>Publish or schedule</h3>
+              <p>Choose when to send the selected platform drafts.</p>
+            </div>
+          </div>
+
+          <div className="feed-schedule-row">
+            <div className="feed-publish-toggle" aria-label="Publishing time">
+              <button
+                className={publishMode === "now" ? "feed-publish-option feed-publish-option--active" : "feed-publish-option"}
+                onClick={() => setPublishMode("now")}
+                type="button"
+              >
+                Publish now
+              </button>
+              <button
+                className={publishMode === "schedule" ? "feed-publish-option feed-publish-option--active" : "feed-publish-option"}
+                onClick={() => setPublishMode("schedule")}
+                type="button"
+              >
+                Schedule
+              </button>
+            </div>
+            {publishMode === "schedule" && (
+              <div className="feed-date-fields">
+                <input
+                  className="field-input"
+                  aria-label="Schedule date"
+                  onChange={(event) => setScheduleDate(event.target.value)}
+                  type="date"
+                  value={scheduleDate}
+                />
+                <input
+                  className="field-input"
+                  aria-label="Schedule time"
+                  onChange={(event) => setScheduleTime(event.target.value)}
+                  type="time"
+                  value={scheduleTime}
+                />
+              </div>
+            )}
+          </div>
+
+          {selectedInstagramWithoutMedia && (
+            <p className="message message--error">Instagram requires a hosted image URL.</p>
+          )}
+
+          <div className="feed-composer-actions">
+            <button
+              className="btn btn--ghost"
+              type="button"
+              disabled={!canSave || working}
+              onClick={() => submitPost("draft")}
+            >
+              Save draft
+            </button>
+            <button
+              className="btn btn--ghost"
+              type="button"
+              disabled={!canPreview}
+              onClick={() => setNotice("Review each selected platform draft above before publishing.")}
+            >
+              Review selected
+            </button>
+            <button
+              className="btn btn--primary"
+              type="button"
+              disabled={!canSubmit || working}
+              onClick={() => submitPost(publishMode)}
+            >
+              {working
+                ? "Working…"
+                : publishMode === "schedule"
+                  ? "Schedule selected"
+                  : "Publish selected"}
+            </button>
+          </div>
+        </section>
+
+        <div className="feed-secondary-grid">
+          <section className="portal-card">
+            <div className="portal-card-heading">
+              <h2>Saved drafts</h2>
+              <span className="portal-count">{savedDrafts.length}</span>
+            </div>
+            {savedDrafts.length ? (
+              <div className="feed-post-list">
+                {savedDrafts.map((post) => (
+                  <article className="feed-post-summary" key={post.id}>
+                    <strong>{post.master_caption}</strong>
+                    <small>{new Date(post.created_at).toLocaleString()}</small>
+                    <span>{post.targets.map((target) => target.provider).join(", ")}</span>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <div className="feed-empty-state">
+                <span aria-hidden="true">◇</span>
+                <strong>No saved drafts</strong>
+                <p>Save a prepared post to finish it later.</p>
+              </div>
+            )}
+          </section>
+
+          <section className="portal-card">
+            <div className="portal-card-heading">
+              <h2>Upcoming posts</h2>
+              <span className="portal-count">{scheduledPosts.length}</span>
+            </div>
+            {scheduledPosts.length ? (
+              <div className="feed-post-list">
+                {scheduledPosts.map((post) => (
+                  <article className="feed-post-summary" key={post.id}>
+                    <strong>{post.master_caption}</strong>
+                    <small>{new Date(post.scheduled_at).toLocaleString()}</small>
+                    <span>{post.targets.map((target) => target.provider).join(", ")}</span>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <div className="feed-empty-state">
+                <span aria-hidden="true">◷</span>
+                <strong>No posts scheduled</strong>
+                <p>Your scheduled content will appear here.</p>
+              </div>
+            )}
+          </section>
+
+          <section className="portal-card">
+            <div className="portal-card-heading">
+              <h2>Connected accounts</h2>
+              <span className="portal-count">{connectedProviders.size}</span>
+            </div>
+            {loading ? (
+              <p className="portal-card-description">Loading destinations…</p>
+            ) : connectedProviders.size ? (
+              <div className="feed-connected-list">
+                {connections.filter((connection) => connectedProviders.has(connection.provider)).map((connection) => (
+                  <div key={connection.provider}>
+                    <strong>{connection.name}</strong>
+                    <span>{connection.provider_account_name}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="portal-card-description">
+                No publishing destinations are connected.{" "}
+                <Link to={`/org/${orgId}/social`}>Connect social accounts</Link>.
+              </p>
+            )}
+          </section>
+
+          {posts.some((post) => ["failed", "partial_failure"].includes(post.status)) && (
+            <section className="portal-card feed-failures-card">
+              <div className="portal-card-heading">
+                <h2>Needs attention</h2>
+              </div>
+              <div className="feed-post-list">
+                {posts.filter((post) => ["failed", "partial_failure"].includes(post.status)).map((post) => (
+                  <article className="feed-post-summary" key={post.id}>
+                    <strong>{postStatusLabel(post.status)}</strong>
+                    {post.targets.filter((target) => target.error).map((target) => (
+                      <small key={target.id}>{target.provider}: {target.error}</small>
+                    ))}
+                  </article>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/FeedbackPage.jsx
+++ b/frontend/src/components/FeedbackPage.jsx
@@ -88,7 +88,9 @@ export default function FeedbackPage() {
       <div className="feedback-page">
         <div className="feedback-card">
 <h2 className="feedback-title">Feedback submitted</h2>
-          <p className="feedback-subtitle">Thank you for sharing with <strong>{orgInfo.organization_name}</strong>.</p>
+          <p className="feedback-subtitle">
+            Thank you for sharing with <strong>{orgInfo.organization_name} · {orgInfo.location_name}</strong>.
+          </p>
 
           {reviewLinks.length > 0 && (
             <div className="review-share-section">
@@ -167,7 +169,9 @@ export default function FeedbackPage() {
     <div className="feedback-page">
       <div className="feedback-card">
         <h2 className="feedback-title">Share Your Feedback</h2>
-        <p className="feedback-subtitle">Send anonymous feedback to <strong>{orgInfo.organization_name}</strong></p>
+        <p className="feedback-subtitle">
+          Send anonymous feedback to <strong>{orgInfo.organization_name} · {orgInfo.location_name}</strong>
+        </p>
 
         <form className="feedback-form" onSubmit={handleSubmit}>
           <label className="field-label" htmlFor="content">Your feedback *</label>

--- a/frontend/src/components/InitiativesManager.jsx
+++ b/frontend/src/components/InitiativesManager.jsx
@@ -1,0 +1,301 @@
+import { useEffect, useState } from "react";
+import {
+  createOrganizationInitiative,
+  deleteOrganizationInitiative,
+  listOrganizationInitiatives,
+  updateOrganizationInitiative,
+} from "../api";
+
+const STATUSES = [
+  { value: "gathering_feedback", label: "Gathering feedback" },
+  { value: "planned", label: "Planned" },
+  { value: "in_progress", label: "In progress" },
+  { value: "shipped", label: "Shipped" },
+];
+
+function statusLabel(status) {
+  return STATUSES.find((option) => option.value === status)?.label || status;
+}
+
+function InitiativeEditor({ initiative, onCancel, onSave, saving }) {
+  const [title, setTitle] = useState(initiative.title);
+  const [description, setDescription] = useState(initiative.description);
+  const [status, setStatus] = useState(initiative.status);
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    onSave({ title, description, status });
+  }
+
+  return (
+    <form className="initiative-edit-form" onSubmit={handleSubmit}>
+      <label className="field-label" htmlFor={`initiative-title-${initiative.id}`}>Title</label>
+      <input
+        className="field-input"
+        id={`initiative-title-${initiative.id}`}
+        value={title}
+        maxLength={160}
+        required
+        onChange={(event) => setTitle(event.target.value)}
+      />
+      <label className="field-label" htmlFor={`initiative-description-${initiative.id}`}>Details</label>
+      <textarea
+        className="field-textarea"
+        id={`initiative-description-${initiative.id}`}
+        value={description}
+        rows="4"
+        maxLength={5000}
+        required
+        onChange={(event) => setDescription(event.target.value)}
+      />
+      <label className="field-label" htmlFor={`initiative-status-${initiative.id}`}>Status</label>
+      <select
+        className="field-select"
+        id={`initiative-status-${initiative.id}`}
+        value={status}
+        onChange={(event) => setStatus(event.target.value)}
+      >
+        {STATUSES.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+      </select>
+      <div className="initiative-edit-actions">
+        <button className="btn btn--primary btn--sm" type="submit" disabled={saving}>{saving ? "Saving…" : "Save changes"}</button>
+        <button className="btn btn--ghost btn--sm" type="button" onClick={onCancel} disabled={saving}>Cancel</button>
+      </div>
+    </form>
+  );
+}
+
+export default function InitiativesManager({
+  token,
+  orgId,
+  isAdmin,
+  locationId,
+  locations = [],
+  publicBoardUrl,
+}) {
+  const [initiatives, setInitiatives] = useState([]);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState("gathering_feedback");
+  const [destinationLocationId, setDestinationLocationId] = useState(
+    locationId || locations[0]?.id || ""
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [editingId, setEditingId] = useState(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    async function loadInitiatives() {
+      setIsLoading(true);
+      setError("");
+      try {
+        const result = await listOrganizationInitiatives(token, orgId, locationId);
+        if (active) setInitiatives(result);
+      } catch (err) {
+        if (active) setError(err.message);
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    }
+    loadInitiatives();
+    return () => { active = false; };
+  }, [locationId, orgId, token]);
+
+  useEffect(() => {
+    setTitle("");
+    setDescription("");
+    setStatus("gathering_feedback");
+    setEditingId(null);
+    setDestinationLocationId(locationId || "");
+  }, [locationId, orgId]);
+
+  useEffect(() => {
+    if (
+      !locationId
+      && !locations.some((location) => location.id === Number(destinationLocationId))
+    ) {
+      setDestinationLocationId(locations[0]?.id || "");
+    }
+  }, [destinationLocationId, locationId, locations]);
+
+  async function handleCreate(event) {
+    event.preventDefault();
+    setIsSaving(true);
+    setError("");
+    try {
+      const created = await createOrganizationInitiative(token, orgId, {
+        title,
+        description,
+        status,
+        location_id: Number(destinationLocationId),
+      });
+      setInitiatives((current) => [created, ...current]);
+      setTitle("");
+      setDescription("");
+      setStatus("gathering_feedback");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleUpdate(initiativeId, update) {
+    setIsSaving(true);
+    setError("");
+    try {
+      const saved = await updateOrganizationInitiative(token, orgId, initiativeId, update);
+      setInitiatives((current) => current.map((item) => (item.id === saved.id ? saved : item)));
+      setEditingId(null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDelete(initiative) {
+    if (!window.confirm(`Delete "${initiative.title}"? This cannot be undone.`)) return;
+    setIsSaving(true);
+    setError("");
+    try {
+      await deleteOrganizationInitiative(token, orgId, initiative.id);
+      setInitiatives((current) => current.filter((item) => item.id !== initiative.id));
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <section className="initiatives-manager">
+      <div className="initiatives-manager-heading">
+        <div>
+          <p className="dashboard-kicker">Public roadmap</p>
+          <h3>What you&apos;re working on</h3>
+          <p>Share initiatives on your public page and let visitors show what they care about most.</p>
+        </div>
+        {publicBoardUrl && (
+          <LinkButton href={publicBoardUrl} />
+        )}
+      </div>
+
+      {error && <p className="message message--error">{error}</p>}
+
+      {isAdmin && (
+        <form className="initiative-create-form" onSubmit={handleCreate}>
+          <div className="initiative-form-heading">
+            <strong>Add an initiative</strong>
+            <span>It will appear immediately on your public roadmap.</span>
+          </div>
+          <label className="field-label" htmlFor="initiative-title">Title</label>
+          <input
+            className="field-input"
+            id="initiative-title"
+            placeholder="e.g. Online appointment booking"
+            value={title}
+            maxLength={160}
+            required
+            onChange={(event) => setTitle(event.target.value)}
+          />
+          <label className="field-label" htmlFor="initiative-description">What are you working on?</label>
+          <textarea
+            className="field-textarea"
+            id="initiative-description"
+            placeholder="Share the context, goal, or customer benefit."
+            rows="4"
+            value={description}
+            maxLength={5000}
+            required
+            onChange={(event) => setDescription(event.target.value)}
+          />
+          <div className="initiative-create-footer">
+            <div className="initiative-create-selects">
+              {!locationId && (
+                <label className="initiative-status-select" htmlFor="initiative-location">
+                  <span>Location</span>
+                  <select
+                    id="initiative-location"
+                    className="field-select"
+                    value={destinationLocationId}
+                    required
+                    onChange={(event) => setDestinationLocationId(event.target.value)}
+                  >
+                    {locations.map((location) => (
+                      <option key={location.id} value={location.id}>{location.name}</option>
+                    ))}
+                  </select>
+                </label>
+              )}
+              <label className="initiative-status-select" htmlFor="initiative-status">
+                <span>Status</span>
+                <select id="initiative-status" className="field-select" value={status} onChange={(event) => setStatus(event.target.value)}>
+                  {STATUSES.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+              </label>
+            </div>
+            <button className="btn btn--primary" type="submit" disabled={isSaving}>{isSaving ? "Posting…" : "Post to roadmap"}</button>
+          </div>
+        </form>
+      )}
+
+      <div className="initiative-admin-list">
+        <div className="initiative-admin-list-heading">
+          <h4>{isAdmin ? "Published initiatives" : "Initiatives"}</h4>
+          {!isLoading && <span>{initiatives.length}</span>}
+        </div>
+        {isLoading ? (
+          <p className="initiative-list-state">Loading initiatives…</p>
+        ) : initiatives.length ? (
+          initiatives.map((initiative) => (
+            <article className="initiative-admin-card" key={initiative.id}>
+              {editingId === initiative.id ? (
+                <InitiativeEditor
+                  initiative={initiative}
+                  saving={isSaving}
+                  onCancel={() => setEditingId(null)}
+                  onSave={(update) => handleUpdate(initiative.id, update)}
+                />
+              ) : (
+                <>
+                  <div className="initiative-admin-card-copy">
+                    <div className="initiative-admin-meta">
+                      {!locationId && <span className="initiative-location-badge">{initiative.location_name}</span>}
+                      <span className={`initiative-status initiative-status--${initiative.status}`}>{statusLabel(initiative.status)}</span>
+                      <span>{initiative.score > 0 ? "+" : ""}{initiative.score} score</span>
+                      <span>{initiative.upvotes} up · {initiative.downvotes} down</span>
+                    </div>
+                    <h5>{initiative.title}</h5>
+                    <p>{initiative.description}</p>
+                  </div>
+                  {isAdmin && (
+                    <div className="initiative-admin-actions">
+                      <button className="btn btn--ghost btn--sm" type="button" disabled={isSaving} onClick={() => setEditingId(initiative.id)}>Edit</button>
+                      <button className="btn btn--ghost btn--sm initiative-delete-button" type="button" disabled={isSaving} onClick={() => handleDelete(initiative)}>Delete</button>
+                    </div>
+                  )}
+                </>
+              )}
+            </article>
+          ))
+        ) : (
+          <p className="initiative-list-state">{isAdmin ? "Post your first initiative to get the roadmap started." : "No initiatives have been posted yet."}</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function LinkButton({ href }) {
+  return (
+    <a className="btn btn--ghost btn--sm initiatives-public-link" href={href} target="_blank" rel="noreferrer">
+      <span>Open public page</span>
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M7 13 13 7M8 7h5v5" />
+      </svg>
+    </a>
+  );
+}

--- a/frontend/src/components/InviteAcceptPage.jsx
+++ b/frontend/src/components/InviteAcceptPage.jsx
@@ -2,6 +2,13 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { acceptInvite, getInviteInfo } from "../api";
 
+const ACCESS_ROLE_LABELS = {
+  organization_admin: "Organization admin",
+  organization_viewer: "Organization viewer",
+  location_admin: "Location admin",
+  location_viewer: "Location viewer",
+};
+
 export default function InviteAcceptPage({ token, isAuthenticated }) {
   const { inviteToken } = useParams();
   const navigate = useNavigate();
@@ -70,7 +77,8 @@ export default function InviteAcceptPage({ token, isAuthenticated }) {
       <div className="invite-card">
         <h2 className="invite-title">You've been invited!</h2>
         <p className="invite-detail">
-          Join <strong>{info.organization_name}</strong> as a <strong>{info.role}</strong>
+          Join <strong>{info.organization_name}</strong>
+          {info.location_name && <> at <strong>{info.location_name}</strong></>} as a <strong>{ACCESS_ROLE_LABELS[info.role] || info.role}</strong>
         </p>
 
         {error && <p className="message message--error">{error}</p>}

--- a/frontend/src/components/InviteList.jsx
+++ b/frontend/src/components/InviteList.jsx
@@ -1,15 +1,27 @@
 import { useEffect, useState } from "react";
 import { createInvite, listInvites } from "../api";
 
-export default function InviteList({ token, orgId, isAdmin }) {
+const ACCESS_ROLE_LABELS = {
+  organization_admin: "Organization admin",
+  organization_viewer: "Organization viewer",
+  location_admin: "Location admin",
+  location_viewer: "Location viewer",
+};
+
+export default function InviteList({ token, orgId, isAdmin, locations = [] }) {
   const [invites, setInvites] = useState([]);
-  const [newRole, setNewRole] = useState("viewer");
+  const [newRole, setNewRole] = useState("location_admin");
+  const [locationId, setLocationId] = useState(locations[0]?.id || "");
   const [error, setError] = useState("");
   const [copied, setCopied] = useState(null);
 
   useEffect(() => {
     if (isAdmin) loadInvites();
   }, [orgId, isAdmin]);
+
+  useEffect(() => {
+    if (!locationId && locations[0]) setLocationId(locations[0].id);
+  }, [locationId, locations]);
 
   async function loadInvites() {
     try {
@@ -23,7 +35,14 @@ export default function InviteList({ token, orgId, isAdmin }) {
   async function handleCreate() {
     setError("");
     try {
-      await createInvite(token, orgId, newRole);
+      const isLocationInvite = newRole.startsWith("location_");
+      await createInvite(
+        token,
+        orgId,
+        newRole,
+        168,
+        isLocationInvite ? Number(locationId) : null,
+      );
       await loadInvites();
     } catch (err) {
       setError(err.message);
@@ -51,55 +70,65 @@ export default function InviteList({ token, orgId, isAdmin }) {
 
   return (
     <div className="settings-section">
-      <h3 className="settings-heading">Invite Links</h3>
+      <h3 className="settings-heading">Invite users</h3>
       {error && <p className="message message--error">{error}</p>}
 
       <div className="invite-create">
         <select className="role-select" value={newRole} onChange={(e) => setNewRole(e.target.value)}>
-          <option value="viewer">viewer</option>
-          <option value="admin">admin</option>
+          {Object.entries(ACCESS_ROLE_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
         </select>
+        {newRole.startsWith("location_") && (
+          <select className="role-select" value={locationId} onChange={(event) => setLocationId(event.target.value)}>
+            {locations.map((location) => <option key={location.id} value={location.id}>{location.name}</option>)}
+          </select>
+        )}
         <button type="button" className="btn btn--primary btn--sm" onClick={handleCreate}>
           Generate invite link
         </button>
       </div>
 
       {invites.length > 0 && (
-        <table className="members-table">
-          <thead>
-            <tr>
-              <th>Role</th>
-              <th>Status</th>
-              <th>Expires</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {invites.map((inv) => {
-              const st = inviteStatus(inv);
-              return (
-                <tr key={inv.id}>
-                  <td>{inv.role}</td>
-                  <td>
-                    <span className={`invite-status invite-status--${st}`}>{st}</span>
-                  </td>
-                  <td>{new Date(inv.expires_at).toLocaleDateString()}</td>
-                  <td>
-                    {st === "active" && (
-                      <button
-                        type="button"
-                        className="btn btn--ghost btn--sm"
-                        onClick={() => handleCopy(inv.invite_url, inv.id)}
-                      >
-                        {copied === inv.id ? "Copied!" : "Copy link"}
-                      </button>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="settings-table-scroll">
+          <table className="members-table">
+            <thead>
+              <tr>
+                <th>Role</th>
+                <th>Scope</th>
+                <th>Status</th>
+                <th>Expires</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {invites.map((inv) => {
+                const st = inviteStatus(inv);
+                return (
+                  <tr key={inv.id}>
+                    <td>{ACCESS_ROLE_LABELS[inv.role] || inv.role}</td>
+                    <td>{inv.location_name || "All locations"}</td>
+                    <td>
+                      <span className={`invite-status invite-status--${st}`}>{st}</span>
+                    </td>
+                    <td>{new Date(inv.expires_at).toLocaleDateString()}</td>
+                    <td>
+                      {st === "active" && (
+                        <button
+                          type="button"
+                          className="btn btn--ghost btn--sm"
+                          onClick={() => handleCopy(inv.invite_url, inv.id)}
+                        >
+                          {copied === inv.id ? "Copied!" : "Copy link"}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/LocationSwitcher.jsx
+++ b/frontend/src/components/LocationSwitcher.jsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+
+const ACCESS_ROLE_LABELS = {
+  organization_admin: "Organization admin",
+  organization_viewer: "Organization viewer",
+  location_admin: "Location admin",
+  location_viewer: "Location viewer",
+};
+
+export default function LocationSwitcher({
+  canViewAll,
+  currentLocationId,
+  locations,
+  onLocationChange,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  if (!locations.length) return null;
+
+  const currentLocation = locations.find((location) => location.id === Number(currentLocationId));
+  const label = currentLocationId === "all"
+    ? "All locations"
+    : currentLocation?.name || "Select location";
+
+  function choose(value) {
+    onLocationChange(value);
+    setIsOpen(false);
+  }
+
+  return (
+    <div className="location-switcher-wrap">
+      <button
+        type="button"
+        className="location-switcher"
+        onClick={() => setIsOpen((current) => !current)}
+        aria-label="Change location scope"
+        aria-expanded={isOpen}
+      >
+        <span className="location-switcher-pin" aria-hidden="true">⌖</span>
+        <span>{label}</span>
+        <span className="org-switcher-chevron" aria-hidden="true">{isOpen ? "▲" : "▼"}</span>
+      </button>
+
+      {isOpen && (
+        <>
+          <div className="location-switcher-menu">
+            <p className="organization-switcher-heading">Location scope</p>
+            {canViewAll && (
+              <button
+                type="button"
+                className={`organization-switcher-option${currentLocationId === "all" ? " organization-switcher-option--active" : ""}`}
+                onClick={() => choose("all")}
+              >
+                <span>
+                  <strong>All locations</strong>
+                  <small>Organization rollup</small>
+                </span>
+                {currentLocationId === "all" && <span aria-hidden="true">✓</span>}
+              </button>
+            )}
+            {locations.map((location) => (
+              <button
+                type="button"
+                className={`organization-switcher-option${Number(currentLocationId) === location.id ? " organization-switcher-option--active" : ""}`}
+                key={location.id}
+                onClick={() => choose(location.id)}
+              >
+                <span>
+                  <strong>{location.name}</strong>
+                  <small>{ACCESS_ROLE_LABELS[location.access_role] || location.access_role}</small>
+                </span>
+                {Number(currentLocationId) === location.id && <span aria-hidden="true">✓</span>}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="organization-switcher-backdrop"
+            onClick={() => setIsOpen(false)}
+            aria-label="Close location menu"
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/LocationsPage.jsx
+++ b/frontend/src/components/LocationsPage.jsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import { createLocation, deleteLocation, updateLocation } from "../api";
+
+function PublicLink({ label, url }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  }
+
+  return (
+    <div className="location-public-link">
+      <span>{label}</span>
+      <input type="text" readOnly value={url} />
+      <button type="button" className="btn btn--ghost btn--sm" onClick={copy}>
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+export default function LocationsPage({ locations, onLocationsChanged, orgId, token }) {
+  const [name, setName] = useState("");
+  const [address, setAddress] = useState("");
+  const [timezone, setTimezone] = useState("America/Chicago");
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleCreate(event) {
+    event.preventDefault();
+    setIsSaving(true);
+    setError("");
+    try {
+      await createLocation(token, orgId, { name, address: address || null, timezone });
+      setName("");
+      setAddress("");
+      await onLocationsChanged();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleRename(location) {
+    const nextName = window.prompt("Location name", location.name);
+    if (!nextName?.trim() || nextName.trim() === location.name) return;
+    setError("");
+    try {
+      await updateLocation(token, orgId, location.id, { name: nextName.trim() });
+      await onLocationsChanged();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function handleDelete(location) {
+    if (!window.confirm(`Delete "${location.name}"?`)) return;
+    setError("");
+    try {
+      await deleteLocation(token, orgId, location.id);
+      await onLocationsChanged();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="locations-page">
+      <header className="portal-page-heading">
+        <p className="dashboard-kicker">Admin</p>
+        <h1>Locations</h1>
+        <p>Partition feedback, roadmap items, public links, and team access by business location.</p>
+      </header>
+
+      {error && <p className="message message--error">{error}</p>}
+
+      <section className="portal-card location-create-card">
+        <div className="portal-card-heading">
+          <div>
+            <h2>Add a location</h2>
+            <p className="portal-card-description">Each location gets its own feedback and roadmap links.</p>
+          </div>
+        </div>
+        <form className="location-create-form" onSubmit={handleCreate}>
+          <div className="location-create-fields">
+            <label className="location-create-field" htmlFor="location-name">
+              <span className="field-label">Location name</span>
+              <input
+                className="field-input"
+                id="location-name"
+                placeholder="Downtown Baton Rouge"
+                required
+                maxLength="255"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </label>
+            <label className="location-create-field" htmlFor="location-address">
+              <span className="field-label">Address <span className="optional-label">Optional</span></span>
+              <input
+                className="field-input"
+                id="location-address"
+                placeholder="123 Main Street"
+                maxLength="500"
+                value={address}
+                onChange={(event) => setAddress(event.target.value)}
+              />
+            </label>
+            <label className="location-create-field" htmlFor="location-timezone">
+              <span className="field-label">Timezone</span>
+              <select
+                className="field-select"
+                id="location-timezone"
+                value={timezone}
+                onChange={(event) => setTimezone(event.target.value)}
+              >
+                <option value="America/Chicago">Central time</option>
+                <option value="America/New_York">Eastern time</option>
+                <option value="America/Denver">Mountain time</option>
+                <option value="America/Los_Angeles">Pacific time</option>
+              </select>
+            </label>
+          </div>
+          <div className="location-create-actions">
+            <button type="submit" className="btn btn--primary" disabled={isSaving}>
+              {isSaving ? "Adding…" : "Add location"}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="location-card-list" aria-label="Organization locations">
+        {locations.map((location) => (
+          <article className="portal-card location-card" key={location.id}>
+            <div className="location-card-heading">
+              <div>
+                <div className="location-title-row">
+                  <h2>{location.name}</h2>
+                  {location.is_default && <span className="status-pill status-pill--soon">Default</span>}
+                </div>
+                <p>{location.address || "No address added"} · {location.timezone}</p>
+              </div>
+              <div className="location-card-actions">
+                <button className="btn btn--ghost btn--sm" type="button" onClick={() => handleRename(location)}>Rename</button>
+                {!location.is_default && (
+                  <button className="btn btn--ghost btn--sm initiative-delete-button" type="button" onClick={() => handleDelete(location)}>Delete</button>
+                )}
+              </div>
+            </div>
+            <div className="location-public-links">
+              <PublicLink
+                label="Feedback"
+                url={`${window.location.origin}/feedback/${location.feedback_token}`}
+              />
+              <PublicLink
+                label="Roadmap"
+                url={`${window.location.origin}/roadmap/${location.feedback_token}`}
+              />
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/MemberList.jsx
+++ b/frontend/src/components/MemberList.jsx
@@ -1,7 +1,69 @@
 import { useEffect, useState } from "react";
-import { listMembers, updateMemberRole, removeMember } from "../api";
+import {
+  listMembers,
+  removeMember,
+  updateMemberLocationAssignments,
+  updateMemberRole,
+} from "../api";
 
-export default function MemberList({ token, orgId, currentUserId, isAdmin }) {
+const ACCESS_ROLE_LABELS = {
+  organization_admin: "Organization admin",
+  organization_viewer: "Organization viewer",
+  location_admin: "Location admin",
+  location_viewer: "Location viewer",
+};
+
+function LocationAccessEditor({ locations, member, onSave }) {
+  const [assignments, setAssignments] = useState(() => (
+    Object.fromEntries((member.location_assignments || []).map((item) => [item.location_id, true]))
+  ));
+  const [isSaving, setIsSaving] = useState(false);
+  const locationRole = member.role === "location_admin" ? "manager" : "viewer";
+
+  async function save() {
+    setIsSaving(true);
+    try {
+      await onSave(
+        Object.keys(assignments).map((locationId) => ({
+          location_id: Number(locationId),
+          role: locationRole,
+        }))
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <details className="member-location-access">
+      <summary>
+        {(member.location_assignments || []).length} location{(member.location_assignments || []).length === 1 ? "" : "s"}
+      </summary>
+      <div className="member-location-menu">
+        {locations.map((location) => (
+          <label className="member-location-option" key={location.id}>
+            <input
+              type="checkbox"
+              checked={Boolean(assignments[location.id])}
+              onChange={(event) => setAssignments((current) => {
+                const next = { ...current };
+                if (event.target.checked) next[location.id] = true;
+                else delete next[location.id];
+                return next;
+              })}
+            />
+            <span>{location.name}</span>
+          </label>
+        ))}
+        <button className="btn btn--primary btn--sm" type="button" onClick={save} disabled={isSaving || !Object.keys(assignments).length}>
+          {isSaving ? "Saving…" : "Save access"}
+        </button>
+      </div>
+    </details>
+  );
+}
+
+export default function MemberList({ token, orgId, currentUserId, isAdmin, locations = [] }) {
   const [members, setMembers] = useState([]);
   const [error, setError] = useState("");
 
@@ -45,54 +107,84 @@ export default function MemberList({ token, orgId, currentUserId, isAdmin }) {
     }
   }
 
+  async function handleAssignments(userId, assignments) {
+    setError("");
+    try {
+      const updated = await updateMemberLocationAssignments(token, orgId, userId, assignments);
+      setMembers((current) => current.map((member) => (
+        member.user_id === userId ? updated : member
+      )));
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    }
+  }
+
   return (
     <div className="settings-section">
-      <h3 className="settings-heading">Members</h3>
+      <h3 className="settings-heading">Users</h3>
       {error && <p className="message message--error">{error}</p>}
 
-      <table className="members-table">
-        <thead>
-          <tr>
-            <th>Email</th>
-            <th>Role</th>
-            <th>Joined</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {members.map((m) => (
-            <tr key={m.user_id} className={m.user_id === currentUserId ? "members-row--self" : ""}>
-              <td>{m.email}</td>
-              <td>
-                {isAdmin ? (
-                  <select
-                    className="role-select"
-                    value={m.role}
-                    onChange={(e) => handleRoleChange(m.user_id, e.target.value)}
-                  >
-                    <option value="admin">admin</option>
-                    <option value="viewer">viewer</option>
-                  </select>
-                ) : (
-                  m.role
-                )}
-              </td>
-              <td>{new Date(m.joined_at).toLocaleDateString()}</td>
-              <td>
-                {(isAdmin || m.user_id === currentUserId) && (
-                  <button
-                    type="button"
-                    className="btn btn--danger btn--sm"
-                    onClick={() => handleRemove(m.user_id)}
-                  >
-                    {m.user_id === currentUserId ? "Leave" : "Remove"}
-                  </button>
-                )}
-              </td>
+      <div className="settings-table-scroll">
+        <table className="members-table">
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Locations</th>
+              <th>Joined</th>
+              <th></th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {members.map((m) => (
+              <tr key={m.user_id} className={m.user_id === currentUserId ? "members-row--self" : ""}>
+                <td>{m.email}</td>
+                <td>
+                  {isAdmin ? (
+                    <select
+                      className="role-select"
+                      value={m.role}
+                      onChange={(e) => handleRoleChange(m.user_id, e.target.value)}
+                    >
+                      {Object.entries(ACCESS_ROLE_LABELS).map(([value, label]) => (
+                        <option key={value} value={value}>{label}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    ACCESS_ROLE_LABELS[m.role] || m.role
+                  )}
+                </td>
+                <td>
+                  {m.role.startsWith("organization_") ? (
+                    <span className="member-all-locations">All locations</span>
+                  ) : isAdmin ? (
+                    <LocationAccessEditor
+                      locations={locations}
+                      member={m}
+                      onSave={(assignments) => handleAssignments(m.user_id, assignments)}
+                    />
+                  ) : (
+                    `${(m.location_assignments || []).length} assigned`
+                  )}
+                </td>
+                <td>{new Date(m.joined_at).toLocaleDateString()}</td>
+                <td>
+                  {(isAdmin || m.user_id === currentUserId) && (
+                    <button
+                      type="button"
+                      className="btn btn--danger btn--sm"
+                      onClick={() => handleRemove(m.user_id)}
+                    >
+                      {m.user_id === currentUserId ? "Leave" : "Remove"}
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/OrgSettingsPage.jsx
+++ b/frontend/src/components/OrgSettingsPage.jsx
@@ -1,56 +1,452 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { deleteOrganization, getOrganization, updateOrganization, updateOrgReviewLinks } from "../api";
+import {
+  beginSocialConnection,
+  completeFacebookConnection,
+  deleteOrganization,
+  disconnectSocialConnection,
+  getFacebookPageOptions,
+  getOrganization,
+  listSocialConnections,
+  updateLocationReviewLinks,
+  updateOrganization,
+} from "../api";
 import InviteList from "./InviteList";
 import MemberList from "./MemberList";
 
 const PLATFORM_LABELS = { google: "Google Reviews", yelp: "Yelp", tripadvisor: "TripAdvisor" };
 const PLATFORMS = Object.keys(PLATFORM_LABELS);
+const ACCESS_ROLE_LABELS = {
+  organization_admin: "Organization admin",
+  organization_viewer: "Organization viewer",
+  location_admin: "Location admin",
+  location_viewer: "Location viewer",
+};
 
-export default function OrgSettingsPage({ token, user }) {
+const SECTION_COPY = {
+  general: {
+    eyebrow: "Admin",
+    title: "Settings",
+    description: "Manage your organization identity and public links.",
+  },
+  users: {
+    eyebrow: "Admin",
+    title: "Users",
+    description: "Manage the people who can access this organization.",
+  },
+  reviews: {
+    eyebrow: "Admin",
+    title: "Public reviews",
+    description: "Choose where happy customers can leave a public review.",
+  },
+  social: {
+    eyebrow: "Admin",
+    title: "Social accounts",
+    description: "Connect the destinations used by your organization feed.",
+  },
+};
+
+function PageHeading({ section }) {
+  const copy = SECTION_COPY[section] || SECTION_COPY.general;
+  return (
+    <header className="portal-page-heading">
+      <p className="dashboard-kicker">{copy.eyebrow}</p>
+      <h1>{copy.title}</h1>
+      <p>{copy.description}</p>
+    </header>
+  );
+}
+
+const SOCIAL_MARKS = {
+  facebook: "f",
+  instagram: "ig",
+  tiktok: "tt",
+};
+
+function SocialAccountsManager({ token, orgId }) {
+  const [accounts, setAccounts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [workingProvider, setWorkingProvider] = useState("");
+  const [unavailableProvider, setUnavailableProvider] = useState("");
+  const [connectionError, setConnectionError] = useState("");
+  const [notice, setNotice] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has("social")) return null;
+    return {
+      type: params.get("social"),
+      provider: params.get("provider"),
+      message: params.get("message"),
+      setup: params.get("setup"),
+    };
+  });
+  const [metaSetup, setMetaSetup] = useState(() => (
+    notice?.type === "selection_required" && notice?.provider === "facebook"
+      ? notice.setup
+      : ""
+  ));
+  const [metaPages, setMetaPages] = useState([]);
+  const [selectedMetaPage, setSelectedMetaPage] = useState("");
+  const [loadingMetaPages, setLoadingMetaPages] = useState(false);
+
+  async function loadAccounts() {
+    setConnectionError("");
+    try {
+      setAccounts(await listSocialConnections(token, orgId));
+    } catch (err) {
+      setConnectionError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadAccounts();
+  }, [token, orgId]);
+
+  useEffect(() => {
+    if (!notice) return;
+    const cleanUrl = `${window.location.pathname}${window.location.hash}`;
+    window.history.replaceState({}, "", cleanUrl);
+  }, [notice]);
+
+  useEffect(() => {
+    if (!metaSetup) return;
+    let active = true;
+    setLoadingMetaPages(true);
+    setConnectionError("");
+    getFacebookPageOptions(token, orgId, metaSetup)
+      .then((result) => {
+        if (!active) return;
+        setMetaPages(result.pages || []);
+        if (result.pages?.length === 1) setSelectedMetaPage(result.pages[0].id);
+      })
+      .catch((err) => {
+        if (active) setConnectionError(err.message);
+      })
+      .finally(() => {
+        if (active) setLoadingMetaPages(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [metaSetup, token, orgId]);
+
+  async function handleConnect(account) {
+    setConnectionError("");
+    setNotice(null);
+    if (!account.configured) {
+      setUnavailableProvider(account.provider);
+      return;
+    }
+    setUnavailableProvider("");
+    setWorkingProvider(account.provider);
+    try {
+      const result = await beginSocialConnection(token, orgId, account.provider);
+      window.location.assign(result.authorization_url);
+    } catch (err) {
+      setConnectionError(err.message);
+      setWorkingProvider("");
+    }
+  }
+
+  async function handleDisconnect(account) {
+    const label = account.provider_account_name
+      ? `${account.name} (${account.provider_account_name})`
+      : account.name;
+    if (!window.confirm(`Disconnect ${label}? Scheduled publishing to this destination will stop.`)) return;
+    setWorkingProvider(account.provider);
+    setConnectionError("");
+    setNotice(null);
+    try {
+      await disconnectSocialConnection(token, orgId, account.provider);
+      await loadAccounts();
+    } catch (err) {
+      setConnectionError(err.message);
+    } finally {
+      setWorkingProvider("");
+    }
+  }
+
+  async function handleMetaPageComplete() {
+    if (!metaSetup || !selectedMetaPage) return;
+    setWorkingProvider("facebook");
+    setConnectionError("");
+    try {
+      const updatedAccounts = await completeFacebookConnection(
+        token,
+        orgId,
+        metaSetup,
+        selectedMetaPage
+      );
+      setAccounts(updatedAccounts);
+      setMetaSetup("");
+      setMetaPages([]);
+      setSelectedMetaPage("");
+      setNotice({ type: "connected", provider: "facebook", message: null });
+    } catch (err) {
+      setConnectionError(err.message);
+    } finally {
+      setWorkingProvider("");
+    }
+  }
+
+  return (
+    <div className="settings-section social-account-list">
+      <div className="settings-section-heading">
+        <div>
+          <h3 className="settings-heading">Publishing destinations</h3>
+          <p className="settings-meta">
+            Choose a network, sign in, and authorize the account your team will use from Feed.
+          </p>
+        </div>
+        {!loading && (
+          <span className="social-connection-count">
+            {accounts.filter((account) => account.connected).length} connected
+          </span>
+        )}
+      </div>
+      {notice?.type === "connected" && (
+        <p className="message message--success">
+          {accounts.find((account) => account.provider === notice.provider)?.name || "Social account"} connected.
+        </p>
+      )}
+      {notice?.type === "error" && (
+        <p className="message message--error">
+          {notice.message || "The social account could not be connected."}
+        </p>
+      )}
+      {metaSetup && (
+        <div className="social-page-picker" role="region" aria-label="Choose a Facebook Page">
+          <div>
+            <strong>Choose the Facebook Page for this organization</strong>
+            <p>
+              Five* will publish to this Page. If it has a professional Instagram account linked,
+              that destination will be connected automatically.
+            </p>
+          </div>
+          {loadingMetaPages ? (
+            <p className="settings-meta">Loading Pages…</p>
+          ) : metaPages.length ? (
+            <div className="social-page-options">
+              {metaPages.map((page) => (
+                <label
+                  className={`social-page-option${selectedMetaPage === page.id ? " social-page-option--selected" : ""}`}
+                  key={page.id}
+                >
+                  <input
+                    checked={selectedMetaPage === page.id}
+                    name="facebook-page"
+                    onChange={() => setSelectedMetaPage(page.id)}
+                    type="radio"
+                    value={page.id}
+                  />
+                  <span>
+                    <strong>{page.name}</strong>
+                    <small>
+                      {page.instagram?.username
+                        ? `Instagram: @${page.instagram.username}`
+                        : "No linked professional Instagram account found"}
+                    </small>
+                  </span>
+                </label>
+              ))}
+            </div>
+          ) : (
+            <p className="message message--error">
+              No Facebook Pages were returned for this account.
+            </p>
+          )}
+          <div className="social-page-picker-actions">
+            <button
+              className="btn btn--ghost btn--sm"
+              onClick={() => {
+                setMetaSetup("");
+                setMetaPages([]);
+                setSelectedMetaPage("");
+              }}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="btn btn--primary btn--sm"
+              disabled={!selectedMetaPage || workingProvider === "facebook"}
+              onClick={handleMetaPageComplete}
+              type="button"
+            >
+              {workingProvider === "facebook" ? "Connecting…" : "Use this Page"}
+            </button>
+          </div>
+        </div>
+      )}
+      {connectionError && <p className="message message--error">{connectionError}</p>}
+      {loading ? (
+        <div className="social-accounts-loading" aria-live="polite">Loading connections…</div>
+      ) : (
+        accounts.map((account) => {
+          const isWorking = workingProvider === account.provider;
+          const requiresReconnect = account.status === "reconnect_required";
+          return (
+            <div className="social-account-row" key={account.provider}>
+              <span className="social-account-mark" aria-hidden="true">
+                {SOCIAL_MARKS[account.provider]}
+              </span>
+              <span className="social-account-copy">
+                <span className="social-account-name-line">
+                  <strong>{account.name}</strong>
+                  {account.connected && !requiresReconnect && (
+                    <span className="status-pill status-pill--connected">Connected</span>
+                  )}
+                  {requiresReconnect && (
+                    <span className="status-pill status-pill--attention">Reconnect</span>
+                  )}
+                </span>
+                <small>
+                  {account.provider_account_name
+                    ? `Connected as ${account.provider_account_name}`
+                    : account.description}
+                </small>
+                {account.linked_page_name && (
+                  <small>Linked through {account.linked_page_name}</small>
+                )}
+                {account.diagnostic && (
+                  <small className="social-account-diagnostic">{account.diagnostic}</small>
+                )}
+                {!account.publishing_enabled && (
+                  <small className="social-account-diagnostic">
+                    Account authorization is available; publishing remains disabled until the
+                    Five* provider integration is approved and completed.
+                  </small>
+                )}
+              </span>
+              <span className="social-account-actions">
+                {account.connected && (
+                  <button
+                    className="btn btn--text btn--sm"
+                    type="button"
+                    disabled={isWorking}
+                    onClick={() => handleDisconnect(account)}
+                  >
+                    Disconnect
+                  </button>
+                )}
+                {account.connected && account.configured && (
+                  <button
+                    className="btn btn--ghost btn--sm"
+                    type="button"
+                    disabled={isWorking}
+                    onClick={() => handleConnect(account)}
+                  >
+                    {isWorking
+                      ? "Opening…"
+                      : account.provider === "facebook"
+                        ? "Change Page"
+                        : "Reconnect"}
+                  </button>
+                )}
+                {!account.connected && (
+                  <button
+                    className="btn btn--ghost btn--sm"
+                    type="button"
+                    disabled={isWorking}
+                    onClick={() => handleConnect(account)}
+                  >
+                    {isWorking ? "Opening…" : "Connect"}
+                  </button>
+                )}
+              </span>
+            </div>
+          );
+        })
+      )}
+      {unavailableProvider && (
+        <div className="social-connection-notice" role="status">
+          <div>
+            <strong>
+              {accounts.find((account) => account.provider === unavailableProvider)?.name} connection is not available yet
+            </strong>
+            <p>
+              There is nothing for your organization to configure. Five* needs to enable this managed connection once;
+              after that, Connect will take you directly to the network to sign in and choose an account.
+            </p>
+          </div>
+          <button
+            className="btn btn--ghost btn--sm"
+            type="button"
+            onClick={() => setUnavailableProvider("")}
+          >
+            Got it
+          </button>
+        </div>
+      )}
+      <p className="social-account-footnote">
+        Connections are shared across this organization. You will never need to enter developer keys here.
+      </p>
+    </div>
+  );
+}
+
+export default function OrgSettingsPage({
+  section = "general",
+  token,
+  user,
+  locations = [],
+  currentLocation = null,
+  canManageLocation = false,
+  onLocationUpdated,
+}) {
   const { id } = useParams();
   const navigate = useNavigate();
   const [org, setOrg] = useState(null);
   const [editName, setEditName] = useState("");
   const [isEditing, setIsEditing] = useState(false);
   const [error, setError] = useState("");
-  const [feedbackUrlCopied, setFeedbackUrlCopied] = useState(false);
-
-  // Review links state: one URL per platform, edited all at once
   const [linkInputs, setLinkInputs] = useState({ google: "", yelp: "", tripadvisor: "" });
   const [reviewLinksError, setReviewLinksError] = useState("");
   const [reviewLinksSaved, setReviewLinksSaved] = useState(false);
 
-  const isAdmin = org?.role === "admin";
+  const isAdmin = Boolean(org?.can_manage_organization);
+  const canManageReviews = isAdmin || canManageLocation;
 
   useEffect(() => {
-    loadOrg();
-  }, [id]);
-
-  async function loadOrg() {
-    try {
-      const data = await getOrganization(token, id);
-      setOrg(data);
-      setEditName(data.name);
-      const inputs = { google: "", yelp: "", tripadvisor: "" };
-      for (const link of data.review_links || []) {
-        if (link.platform in inputs) inputs[link.platform] = link.url;
+    let active = true;
+    async function loadOrg() {
+      try {
+        const data = await getOrganization(token, id);
+        if (!active) return;
+        setOrg(data);
+        setEditName(data.name);
+        const inputs = { google: "", yelp: "", tripadvisor: "" };
+        for (const link of currentLocation?.review_links || data.review_links || []) {
+          if (link.platform in inputs) inputs[link.platform] = link.url;
+        }
+        setLinkInputs(inputs);
+      } catch (err) {
+        if (active) setError(err.message);
       }
-      setLinkInputs(inputs);
-    } catch (err) {
-      setError(err.message);
     }
-  }
+    loadOrg();
+    return () => { active = false; };
+  }, [id, token, currentLocation?.id]);
 
-  async function handleSaveReviewLinks(e) {
-    e.preventDefault();
+  async function handleSaveReviewLinks(event) {
+    event.preventDefault();
     setReviewLinksError("");
     setReviewLinksSaved(false);
     const updated = PLATFORMS
-      .filter((p) => linkInputs[p].trim())
-      .map((p) => ({ platform: p, url: linkInputs[p].trim() }));
+      .filter((platform) => linkInputs[platform].trim())
+      .map((platform) => ({ platform, url: linkInputs[platform].trim() }));
     try {
-      await updateOrgReviewLinks(token, id, updated);
+      if (!currentLocation) {
+        throw new Error("Select one location before editing public review links.");
+      }
+      const savedLocation = await updateLocationReviewLinks(token, id, currentLocation.id, updated);
+      const inputs = { google: "", yelp: "", tripadvisor: "" };
+      for (const link of savedLocation.review_links || []) {
+        if (link.platform in inputs) inputs[link.platform] = link.url;
+      }
+      setLinkInputs(inputs);
+      onLocationUpdated?.(savedLocation);
       setReviewLinksSaved(true);
       setTimeout(() => setReviewLinksSaved(false), 2000);
     } catch (err) {
@@ -58,8 +454,8 @@ export default function OrgSettingsPage({ token, user }) {
     }
   }
 
-  async function handleRename(e) {
-    e.preventDefault();
+  async function handleRename(event) {
+    event.preventDefault();
     setError("");
     try {
       const updated = await updateOrganization(token, id, { name: editName });
@@ -83,116 +479,123 @@ export default function OrgSettingsPage({ token, user }) {
   if (!org) {
     return (
       <div className="settings-page">
-        {error ? <p className="message message--error">{error}</p> : <p>Loading...</p>}
+        {error ? <p className="message message--error">{error}</p> : <p>Loading…</p>}
       </div>
     );
   }
 
   return (
     <div className="settings-page">
-      <button type="button" className="btn btn--ghost btn--sm" onClick={() => navigate("/dashboard")}>
-        ← Back to dashboard
-      </button>
+      <PageHeading section={section} />
+      {error && <p className="message message--error">{error}</p>}
 
-      <div className="settings-section">
-        <h2 className="settings-title">{org.name}</h2>
-        <p className="settings-meta">
-          Your role: <strong>{org.role}</strong>
-        </p>
-
-        {error && <p className="message message--error">{error}</p>}
-
-        {isAdmin && (
-          <div className="settings-actions">
-            {isEditing ? (
-              <form className="inline-form" onSubmit={handleRename}>
-                <input
-                  className="field-input"
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  minLength={1}
-                  maxLength={255}
-                  required
-                />
-                <button type="submit" className="btn btn--primary btn--sm">
-                  Save
-                </button>
-                <button type="button" className="btn btn--ghost btn--sm" onClick={() => setIsEditing(false)}>
-                  Cancel
-                </button>
-              </form>
-            ) : (
-              <button type="button" className="btn btn--ghost btn--sm" onClick={() => setIsEditing(true)}>
-                Rename
-              </button>
+      {section === "general" && (
+        <>
+          <div className="settings-section">
+            <h2 className="settings-title">{org.name}</h2>
+            <p className="settings-meta">Your role: <strong>{ACCESS_ROLE_LABELS[org.role] || org.role}</strong></p>
+            {isAdmin && (
+              <div className="settings-actions">
+                {isEditing ? (
+                  <form className="inline-form" onSubmit={handleRename}>
+                    <input
+                      className="field-input"
+                      value={editName}
+                      onChange={(event) => setEditName(event.target.value)}
+                      minLength={1}
+                      maxLength={255}
+                      required
+                    />
+                    <button type="submit" className="btn btn--primary btn--sm">Save</button>
+                    <button type="button" className="btn btn--ghost btn--sm" onClick={() => setIsEditing(false)}>Cancel</button>
+                  </form>
+                ) : (
+                  <button type="button" className="btn btn--ghost btn--sm" onClick={() => setIsEditing(true)}>Rename</button>
+                )}
+                <button type="button" className="btn btn--danger btn--sm" onClick={handleDelete}>Delete organization</button>
+              </div>
             )}
-            <button type="button" className="btn btn--danger btn--sm" onClick={handleDelete}>
-              Delete organization
-            </button>
           </div>
-        )}
-      </div>
 
-      {isAdmin && org.feedback_token && (
-        <div className="settings-section">
-          <h3 className="settings-heading">Public Feedback URL</h3>
-          <p className="settings-meta">Share this link to receive anonymous feedback:</p>
-          <div className="url-display">
-            <input
-              className="url-input"
-              type="text"
-              readOnly
-              value={`${window.location.origin}/feedback/${org.feedback_token}`}
-            />
-            <button
-              type="button"
-              className="btn btn--primary btn--sm"
-              onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText(`${window.location.origin}/feedback/${org.feedback_token}`);
-                  setFeedbackUrlCopied(true);
-                  setTimeout(() => setFeedbackUrlCopied(false), 2000);
-                } catch {
-                  setError("Failed to copy");
-                }
-              }}
-            >
-              {feedbackUrlCopied ? "Copied!" : "Copy Link"}
-            </button>
-          </div>
-        </div>
+          {isAdmin && (
+            <div className="settings-section">
+              <h3 className="settings-heading">Location public links</h3>
+              <p className="settings-meta">
+                Feedback URLs, roadmap URLs, and review destinations can vary by location.
+                Social publishing connections are shared across the organization.
+              </p>
+              <button
+                className="btn btn--ghost btn--sm"
+                type="button"
+                onClick={() => navigate(`/org/${id}/locations`)}
+                style={{ marginTop: "1rem" }}
+              >
+                Manage locations
+              </button>
+            </div>
+          )}
+        </>
       )}
 
-      {isAdmin && (
+      {section === "users" && (
+        <>
+          <MemberList
+            token={token}
+            orgId={Number(id)}
+            currentUserId={user.id}
+            isAdmin={isAdmin}
+            locations={locations}
+          />
+          <InviteList token={token} orgId={Number(id)} isAdmin={isAdmin} locations={locations} />
+        </>
+      )}
+
+      {section === "reviews" && canManageReviews && (
         <div className="settings-section">
-          <h3 className="settings-heading">Public Review Links</h3>
+          <h3 className="settings-heading">Review destinations</h3>
           <p className="settings-meta">
-            After submitting feedback, customers will see links to leave a public review on these platforms.
-            Leave a field blank to omit that platform.
+            {currentLocation
+              ? `These destinations apply to ${currentLocation.name}. Leave a field blank to omit it.`
+              : "Select one location from the sidebar before editing its public review destinations."}
           </p>
           <form className="review-links-form" onSubmit={handleSaveReviewLinks}>
-            {PLATFORMS.map((p) => (
-              <div key={p} className="review-link-row">
-                <label className="review-link-label">{PLATFORM_LABELS[p]}</label>
+            {PLATFORMS.map((platform) => (
+              <div key={platform} className="review-link-row">
+                <label className="review-link-label" htmlFor={`review-link-${platform}`}>{PLATFORM_LABELS[platform]}</label>
                 <input
                   className="field-input"
+                  id={`review-link-${platform}`}
                   type="url"
-                  placeholder={p === "google" ? "https://g.page/your-business/review" : p === "yelp" ? "https://yelp.com/biz/your-business" : "https://tripadvisor.com/your-listing"}
-                  value={linkInputs[p]}
-                  onChange={(e) => setLinkInputs((prev) => ({ ...prev, [p]: e.target.value }))}
+                  placeholder={
+                    platform === "google"
+                      ? "https://g.page/your-business/review"
+                      : platform === "yelp"
+                        ? "https://yelp.com/biz/your-business"
+                        : "https://tripadvisor.com/your-listing"
+                  }
+                  value={linkInputs[platform]}
+                  onChange={(event) => setLinkInputs((current) => ({ ...current, [platform]: event.target.value }))}
                 />
               </div>
             ))}
             {reviewLinksError && <p className="message message--error">{reviewLinksError}</p>}
-            <button type="submit" className="btn btn--primary btn--sm">
-              {reviewLinksSaved ? "Saved!" : "Save"}
+            <button type="submit" className="btn btn--primary btn--sm" disabled={!currentLocation}>
+              {reviewLinksSaved ? "Saved!" : "Save review links"}
             </button>
           </form>
         </div>
       )}
 
-      <MemberList token={token} orgId={Number(id)} currentUserId={user.id} isAdmin={isAdmin} />
-      <InviteList token={token} orgId={Number(id)} isAdmin={isAdmin} />
+      {section === "social" && isAdmin && (
+        <SocialAccountsManager token={token} orgId={Number(id)} />
+      )}
+
+      {!isAdmin && section !== "users" && !(section === "reviews" && canManageReviews) && (
+        <div className="settings-section">
+          <h3 className="settings-heading">Admin access required</h3>
+          <p className="settings-meta">Only organization admins can manage this section.</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/OrganizationSwitcher.jsx
+++ b/frontend/src/components/OrganizationSwitcher.jsx
@@ -1,87 +1,81 @@
 import { useState } from "react";
 
-export default function OrganizationSwitcher({ organizations, currentOrgId, onOrgChange }) {
+const ACCESS_ROLE_LABELS = {
+  organization_admin: "Organization admin",
+  organization_viewer: "Organization viewer",
+  location_admin: "Location admin",
+  location_viewer: "Location viewer",
+};
+
+export default function OrganizationSwitcher({
+  organizations,
+  currentOrgId,
+  onCreateOrganization,
+  onOrgChange,
+}) {
   const [isOpen, setIsOpen] = useState(false);
   if (!organizations.length) return null;
 
   const currentOrg = organizations.find((org) => org.id === currentOrgId);
-  const displayLabel = currentOrg ? `${currentOrg.name} (${currentOrg.role})` : "Select org";
+  const displayLabel = currentOrg
+    ? `${currentOrg.name} (${ACCESS_ROLE_LABELS[currentOrg.role] || currentOrg.role})`
+    : "Select organization";
+
+  function chooseOrganization(orgId) {
+    onOrgChange(orgId);
+    setIsOpen(false);
+  }
 
   return (
-    <div style={{ position: "relative" }}>
+    <div className="organization-switcher-wrap">
       <button
         type="button"
         className="org-switcher"
-        onClick={() => setIsOpen((v) => !v)}
+        onClick={() => setIsOpen((current) => !current)}
         aria-label="Switch organization"
         aria-expanded={isOpen}
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: "0.5rem",
-        }}
       >
-        <span style={{ flex: 1, textAlign: "left" }}>{displayLabel}</span>
-        <span style={{ fontSize: "0.75rem", color: "var(--color-neutral)" }}>▼</span>
+        <span>{displayLabel}</span>
+        <span className="org-switcher-chevron" aria-hidden="true">{isOpen ? "▲" : "▼"}</span>
       </button>
 
       {isOpen && (
-        <div
-          style={{
-            position: "absolute",
-            top: "calc(100% + 8px)",
-            left: 0,
-            minWidth: "100%",
-            border: "1px solid var(--color-border)",
-            borderRadius: "12px",
-            background: "var(--color-white)",
-            boxShadow: "0 4px 12px color-mix(in srgb, var(--color-ink) 10%, transparent)",
-            zIndex: 40,
-            overflow: "hidden",
-          }}
-        >
-          {organizations.map((org) => (
+        <>
+          <div className="organization-switcher-menu">
+            <p className="organization-switcher-heading">Your organizations</p>
+            {organizations.map((org) => (
+              <button
+                key={org.id}
+                type="button"
+                className={`organization-switcher-option${org.id === currentOrgId ? " organization-switcher-option--active" : ""}`}
+                onClick={() => chooseOrganization(org.id)}
+              >
+                <span>
+                  <strong>{org.name}</strong>
+                  <small>{ACCESS_ROLE_LABELS[org.role] || org.role}</small>
+                </span>
+                {org.id === currentOrgId && <span aria-hidden="true">✓</span>}
+              </button>
+            ))}
             <button
-              key={org.id}
               type="button"
+              className="organization-switcher-create"
               onClick={() => {
-                onOrgChange(org.id);
                 setIsOpen(false);
+                onCreateOrganization();
               }}
-              style={{
-                width: "100%",
-                textAlign: "left",
-                padding: "0.65rem 0.8rem",
-                border: "none",
-                background: org.id === currentOrgId ? "var(--color-primary-soft)" : "var(--color-white)",
-                cursor: "pointer",
-                fontSize: "0.95rem",
-                color: "var(--color-ink)",
-                fontWeight: org.id === currentOrgId ? 700 : 400,
-                borderBottom: "1px solid var(--color-border-muted)",
-              }}
-              onMouseEnter={(e) => (e.target.style.background = "var(--color-surface-alt)")}
-              onMouseLeave={(e) =>
-                (e.target.style.background =
-                  org.id === currentOrgId ? "var(--color-primary-soft)" : "var(--color-white)")
-              }
             >
-              {org.name} ({org.role})
+              <span aria-hidden="true">＋</span>
+              Create organization
             </button>
-          ))}
-        </div>
-      )}
-
-      {isOpen && (
-        <div
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 30,
-          }}
-          onClick={() => setIsOpen(false)}
-        />
+          </div>
+          <button
+            type="button"
+            className="organization-switcher-backdrop"
+            onClick={() => setIsOpen(false)}
+            aria-label="Close organization menu"
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/VotingBoardPage.jsx
+++ b/frontend/src/components/VotingBoardPage.jsx
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getPublicBoard, updatePublicInitiativeVote } from "../api";
+
+const VISITOR_KEY = "five-star-board-visitor-id";
+
+const STATUS_OPTIONS = [
+  { value: "", label: "All" },
+  { value: "gathering_feedback", label: "Gathering feedback" },
+  { value: "planned", label: "Planned" },
+  { value: "in_progress", label: "In progress" },
+  { value: "shipped", label: "Shipped" },
+];
+
+const SORT_OPTIONS = [
+  { value: "top", label: "Top" },
+  { value: "new", label: "New" },
+  { value: "updated", label: "Recently updated" },
+];
+
+function visitorId() {
+  try {
+    const stored = localStorage.getItem(VISITOR_KEY);
+    if (stored) return stored;
+    const generated = globalThis.crypto?.randomUUID?.() || `visitor-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    localStorage.setItem(VISITOR_KEY, generated);
+    return generated;
+  } catch {
+    return `visitor-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+function relativeDate(value) {
+  const elapsed = Date.now() - new Date(value).getTime();
+  const minutes = Math.round(elapsed / 60000);
+  if (minutes < 2) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 14) return `${days}d ago`;
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
+}
+
+function scoreLabel(score) {
+  return score > 0 ? `+${score}` : String(score);
+}
+
+export default function VotingBoardPage() {
+  const { feedbackToken } = useParams();
+  const [board, setBoard] = useState(null);
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState("");
+  const [sort, setSort] = useState("top");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [votingId, setVotingId] = useState(null);
+
+  const loadBoard = useCallback(async () => {
+    setIsLoading(true);
+    setError("");
+    try {
+      const data = await getPublicBoard(feedbackToken, { query: search, status, sort, visitorId: visitorId() });
+      setBoard(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [feedbackToken, search, sort, status]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(loadBoard, search ? 250 : 0);
+    return () => window.clearTimeout(timer);
+  }, [loadBoard, search]);
+
+  async function handleVote(initiative, value) {
+    const nextValue = initiative.viewer_vote === value ? null : value;
+    setVotingId(initiative.id);
+    setError("");
+    try {
+      const updated = await updatePublicInitiativeVote(feedbackToken, initiative.id, nextValue, visitorId());
+      setBoard((current) => current && {
+        ...current,
+        initiatives: current.initiatives.map((item) => (item.id === updated.id ? updated : item)),
+      });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setVotingId(null);
+    }
+  }
+
+  if (isLoading && !board) {
+    return <div className="board-page board-page--centered"><p className="board-state">Loading the roadmap…</p></div>;
+  }
+
+  if (error && !board) {
+    return (
+      <div className="board-page board-page--centered">
+        <div className="board-state-card">
+          <p className="board-eyebrow">Five Star</p>
+          <h1>Roadmap not found</h1>
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const initiatives = board?.initiatives || [];
+
+  return (
+    <div className="board-page">
+      <section className="board-hero">
+        <p className="board-eyebrow">What we&apos;re working on</p>
+        <h1>{board?.organization_name}</h1>
+        <p className="board-location-name">{board?.location_name}</p>
+        <p className="board-intro">Explore what&apos;s ahead, share what matters most, and watch ideas take shape.</p>
+      </section>
+
+      <section className="board-content" aria-label="Organization initiatives">
+        <div className="board-toolbar">
+          <label className="board-search">
+            <span className="sr-only">Search initiatives</span>
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="6" />
+              <path d="m16 16 4 4" />
+            </svg>
+            <input
+              type="search"
+              placeholder="Search what we&apos;re working on"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </label>
+
+          <div className="board-sort" aria-label="Sort initiatives">
+            {SORT_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={`board-sort-button${sort === option.value ? " board-sort-button--active" : ""}`}
+                onClick={() => setSort(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="board-filters" aria-label="Filter by status">
+          {STATUS_OPTIONS.map((option) => (
+            <button
+              key={option.value || "all"}
+              type="button"
+              className={`board-filter${status === option.value ? " board-filter--active" : ""}`}
+              onClick={() => setStatus(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {error && <p className="message message--error board-request-error">{error}</p>}
+
+        {isLoading ? (
+          <p className="board-state board-state--inline">Refreshing initiatives…</p>
+        ) : initiatives.length ? (
+          <div className="initiative-list">
+            {initiatives.map((initiative) => (
+              <article className="public-initiative-card" key={initiative.id}>
+                <div className="initiative-votes" aria-label={`${initiative.score} vote score`}>
+                  <button
+                    type="button"
+                    className={`initiative-vote-button${initiative.viewer_vote === 1 ? " initiative-vote-button--active" : ""}`}
+                    onClick={() => handleVote(initiative, 1)}
+                    disabled={votingId === initiative.id}
+                    aria-label={`Upvote ${initiative.title}`}
+                    aria-pressed={initiative.viewer_vote === 1}
+                  >
+                    <span aria-hidden="true">↑</span>
+                  </button>
+                  <strong className="initiative-score">{scoreLabel(initiative.score)}</strong>
+                  <button
+                    type="button"
+                    className={`initiative-vote-button${initiative.viewer_vote === -1 ? " initiative-vote-button--active initiative-vote-button--down" : ""}`}
+                    onClick={() => handleVote(initiative, -1)}
+                    disabled={votingId === initiative.id}
+                    aria-label={`Downvote ${initiative.title}`}
+                    aria-pressed={initiative.viewer_vote === -1}
+                  >
+                    <span aria-hidden="true">↓</span>
+                  </button>
+                  <span className="initiative-vote-detail">{initiative.upvotes} up · {initiative.downvotes} down</span>
+                </div>
+
+                <div className="initiative-copy">
+                  <div className="initiative-meta">
+                    <span className={`initiative-status initiative-status--${initiative.status}`}>
+                      {STATUS_OPTIONS.find((option) => option.value === initiative.status)?.label || initiative.status}
+                    </span>
+                    <span>Updated {relativeDate(initiative.updated_at)}</span>
+                  </div>
+                  <h2>{initiative.title}</h2>
+                  <p>{initiative.description}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="board-empty-state">
+            <h2>{search || status ? "No matching initiatives" : "Nothing here just yet"}</h2>
+            <p>{search || status ? "Try another search or status." : "Check back soon to see what we're working on."}</p>
+          </div>
+        )}
+
+        <p className="board-vote-note">Votes are anonymous and help this team understand what matters most.</p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1753,8 +1753,15 @@ select {
 
 /* Members table */
 
+.settings-table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
 .members-table {
   width: 100%;
+  min-width: 680px;
   border-collapse: collapse;
   font-size: 0.93rem;
 }
@@ -2172,13 +2179,14 @@ select {
 .review-links-form {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.8rem;
 }
 
 .review-link-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .review-link-label {
@@ -2186,7 +2194,11 @@ select {
   font-size: 0.88rem;
   color: var(--color-ink);
   white-space: nowrap;
-  min-width: 120px;
+}
+
+.review-link-row .field-input {
+  min-width: 0;
+  margin-bottom: 0;
 }
 
 .field-select {
@@ -2995,5 +3007,2490 @@ html {
 
   .demo-dash-panel {
     padding: 1rem 0.8rem;
+  }
+}
+
+/* ── Organization voting board ─────────────────────────────────────────── */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.board-page {
+  min-height: calc(100vh - 84px);
+  padding: 4.5rem 1.5rem 5rem;
+  background:
+    radial-gradient(circle at 12% 4%, color-mix(in srgb, var(--color-primary) 10%, transparent), transparent 26rem),
+    var(--color-bg);
+}
+
+.board-page--centered {
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.board-hero,
+.board-content {
+  width: min(100%, 920px);
+  margin: 0 auto;
+}
+
+.board-hero {
+  max-width: 720px;
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.board-eyebrow,
+.dashboard-kicker {
+  margin: 0 0 0.7rem;
+  color: var(--color-primary);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.board-hero h1 {
+  margin: 0;
+  color: var(--color-ink);
+  font-family: var(--font-serif);
+  font-size: clamp(2.65rem, 7vw, 4.7rem);
+  font-weight: 500;
+  letter-spacing: -0.055em;
+  line-height: 0.94;
+}
+
+.board-intro {
+  max-width: 570px;
+  margin: 1.25rem auto 0;
+  color: var(--color-text);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.board-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.85rem;
+}
+
+.board-search {
+  flex: 1;
+  min-width: 0;
+  max-width: 450px;
+  min-height: 48px;
+  padding: 0 0.95rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  box-shadow: var(--shadow-control);
+}
+
+.board-search:focus-within {
+  border-color: color-mix(in srgb, var(--color-primary) 55%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 14%, transparent);
+}
+
+.board-search svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+}
+
+.board-search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-ink);
+  font: inherit;
+  font-size: 0.93rem;
+}
+
+.board-search input::placeholder {
+  color: var(--color-muted);
+}
+
+.board-sort,
+.board-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.board-sort {
+  justify-content: flex-end;
+}
+
+.board-sort-button,
+.board-filter {
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-muted);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 750;
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease, background-color 140ms ease;
+}
+
+.board-sort-button {
+  padding: 0.55rem 0.7rem;
+}
+
+.board-sort-button:hover,
+.board-sort-button--active {
+  color: var(--color-ink);
+  background: var(--color-surface);
+  border-color: color-mix(in srgb, var(--color-ink) 10%, transparent);
+}
+
+.board-filters {
+  padding-bottom: 1.3rem;
+  margin-bottom: 1.45rem;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.board-filter {
+  padding: 0.46rem 0.75rem;
+  border-color: var(--color-border);
+  background: color-mix(in srgb, var(--color-surface) 84%, transparent);
+}
+
+.board-filter:hover {
+  color: var(--color-primary);
+  border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+}
+
+.board-filter--active {
+  color: var(--color-white);
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+}
+
+.initiative-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.public-initiative-card {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr);
+  gap: 1.25rem;
+  padding: 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--color-ink) 10%, transparent);
+  border-radius: var(--radius-card);
+  background: color-mix(in srgb, var(--color-surface) 96%, transparent);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--color-shadow) 4%, transparent);
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.public-initiative-card:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 28%, transparent);
+  box-shadow: var(--shadow-card);
+  transform: translateY(-2px);
+}
+
+.initiative-votes {
+  align-self: start;
+  display: grid;
+  justify-items: center;
+  gap: 0.1rem;
+}
+
+.initiative-vote-button {
+  width: 34px;
+  height: 28px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1;
+  transition: color 140ms ease, background-color 140ms ease, transform 140ms ease;
+}
+
+.initiative-vote-button:hover:not(:disabled) {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  transform: translateY(-1px);
+}
+
+.initiative-vote-button--active {
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 13%, transparent);
+}
+
+.initiative-vote-button--down:hover:not(:disabled),
+.initiative-vote-button--down.initiative-vote-button--active {
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 9%, transparent);
+}
+
+.initiative-vote-button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.initiative-score {
+  min-width: 2rem;
+  color: var(--color-ink);
+  font-size: 1rem;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.initiative-vote-detail {
+  margin-top: 0.28rem;
+  color: var(--color-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.initiative-copy {
+  min-width: 0;
+}
+
+.initiative-meta,
+.initiative-admin-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem 0.7rem;
+  color: var(--color-muted);
+  font-size: 0.76rem;
+  font-weight: 650;
+  flex-wrap: wrap;
+}
+
+.initiative-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0.18rem 0.52rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.025em;
+  white-space: nowrap;
+}
+
+.initiative-status--gathering_feedback {
+  color: var(--color-status-feedback);
+  background: var(--color-status-feedback-bg);
+}
+
+.initiative-status--planned {
+  color: var(--color-status-planned);
+  background: var(--color-status-planned-bg);
+}
+
+.initiative-status--in_progress {
+  color: var(--color-status-progress);
+  background: var(--color-status-progress-bg);
+}
+
+.initiative-status--shipped {
+  color: var(--color-status-shipped);
+  background: var(--color-status-shipped-bg);
+}
+
+.initiative-copy h2 {
+  margin: 0.7rem 0 0.45rem;
+  color: var(--color-ink);
+  font-size: 1.08rem;
+  line-height: 1.35;
+}
+
+.initiative-copy p {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 0.91rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.board-empty-state,
+.board-state-card {
+  padding: 3rem 1.5rem;
+  border: 1px dashed color-mix(in srgb, var(--color-ink) 18%, transparent);
+  border-radius: var(--radius-card);
+  background: color-mix(in srgb, var(--color-surface) 70%, transparent);
+  text-align: center;
+}
+
+.board-empty-state h2,
+.board-state-card h1 {
+  margin: 0;
+  color: var(--color-ink);
+  font-family: var(--font-serif);
+  font-size: 1.7rem;
+  font-weight: 500;
+}
+
+.board-empty-state p,
+.board-state-card p:not(.board-eyebrow) {
+  margin: 0.65rem 0 0;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.board-state {
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.board-state--inline {
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+}
+
+.board-request-error {
+  margin: 0 0 0.8rem;
+}
+
+.board-vote-note {
+  margin: 1.5rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  text-align: center;
+}
+
+/* ── Initiative management in the owner dashboard ─────────────────────── */
+
+.initiatives-manager {
+  margin: 1.5rem 0;
+  padding: 1.5rem;
+  border: 1px solid color-mix(in srgb, var(--color-ink) 8%, transparent);
+  border-radius: var(--radius-card);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+}
+
+.initiatives-manager-heading h3 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 1.25rem;
+}
+
+.initiatives-manager-heading p:not(.dashboard-kicker) {
+  max-width: 600px;
+  margin: 0.45rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.initiative-create-form {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 1.4rem;
+  padding: 1.15rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 14px;
+  background: var(--color-surface-subtle);
+}
+
+.initiative-form-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.15rem;
+  color: var(--color-ink);
+}
+
+.initiative-form-heading strong {
+  font-size: 0.95rem;
+}
+
+.initiative-form-heading span {
+  color: var(--color-muted);
+  font-size: 0.76rem;
+}
+
+.initiative-create-form .field-input,
+.initiative-create-form .field-textarea,
+.initiative-edit-form .field-input,
+.initiative-edit-form .field-textarea {
+  margin: 0;
+}
+
+.initiative-create-footer {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.25rem;
+}
+
+.initiative-status-select {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--color-muted);
+  font-size: 0.74rem;
+  font-weight: 750;
+}
+
+.initiative-admin-list {
+  margin-top: 1.5rem;
+}
+
+.initiative-admin-list-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.initiative-admin-list-heading h4 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 0.93rem;
+}
+
+.initiative-admin-list-heading span {
+  display: grid;
+  min-width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.initiative-admin-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.initiative-admin-card-copy {
+  min-width: 0;
+}
+
+.initiative-admin-card h5 {
+  margin: 0.55rem 0 0.32rem;
+  color: var(--color-ink);
+  font-size: 0.94rem;
+}
+
+.initiative-admin-card p {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 0.83rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.initiative-admin-actions,
+.initiative-edit-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex: 0 0 auto;
+}
+
+.initiative-delete-button {
+  color: var(--color-danger-text);
+}
+
+.initiative-edit-form {
+  width: 100%;
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.1rem 0;
+}
+
+.initiative-edit-actions {
+  margin-top: 0.3rem;
+}
+
+.initiative-list-state {
+  margin: 0;
+  padding: 1rem 0 0.2rem;
+  color: var(--color-muted);
+  font-size: 0.88rem;
+}
+
+@media (max-width: 760px) {
+  .board-page {
+    padding: 3rem 1rem 3.5rem;
+  }
+
+  .board-hero {
+    margin-bottom: 2.1rem;
+  }
+
+  .board-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .board-search {
+    max-width: none;
+  }
+
+  .board-sort {
+    justify-content: flex-start;
+  }
+
+  .public-initiative-card {
+    grid-template-columns: 60px minmax(0, 1fr);
+    gap: 0.9rem;
+    padding: 1rem;
+  }
+
+  .initiative-vote-detail {
+    font-size: 0.57rem;
+  }
+
+  .initiatives-manager {
+    padding: 1.15rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .board-hero h1 {
+    font-size: 2.75rem;
+  }
+
+  .board-filters {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 1rem;
+  }
+
+  .board-filter {
+    flex: 0 0 auto;
+  }
+
+  .public-initiative-card {
+    grid-template-columns: 1fr;
+  }
+
+  .initiative-votes {
+    grid-template-columns: 34px auto 34px auto;
+    justify-content: start;
+    align-items: center;
+  }
+
+  .initiative-vote-detail {
+    margin: 0 0 0 0.2rem;
+    font-size: 0.66rem;
+  }
+
+  .initiative-create-footer,
+  .initiative-form-heading,
+  .initiative-admin-card {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .initiative-create-footer .btn {
+    width: 100%;
+  }
+
+  .initiative-admin-actions {
+    align-self: flex-start;
+  }
+}
+
+/* ── Authenticated app shell and sidebar ───────────────────────────────── */
+
+.layout--app {
+  --app-sidebar-width: 264px;
+  --app-header-height: 56px;
+  background: var(--color-surface-subtle);
+  overflow-x: clip;
+}
+
+.layout--app .topbar--app {
+  z-index: 60;
+  width: calc(100% - var(--app-sidebar-width));
+  min-height: var(--app-header-height);
+  margin-left: var(--app-sidebar-width);
+  padding: 0.35rem 1.75rem;
+  background: color-mix(in srgb, var(--color-surface) 96%, transparent);
+  justify-content: flex-end;
+}
+
+.layout--sidebar-closed .topbar--app {
+  width: calc(100% - 64px);
+  margin-left: 64px;
+}
+
+.app-journey {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.app-journey-star-wrap {
+  position: relative;
+  width: 24px;
+  height: 28px;
+  border-radius: 7px;
+  color: color-mix(in srgb, var(--color-ink) 24%, transparent);
+  display: grid;
+  place-items: center;
+  outline: none;
+}
+
+.app-journey-star-wrap--earned {
+  color: var(--color-primary);
+}
+
+.app-journey-star-wrap:hover,
+.app-journey-star-wrap:focus-visible {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.app-journey-star {
+  width: 19px;
+  height: 21px;
+  background: currentColor;
+  -webkit-mask-image: var(--journey-asterisk);
+  mask-image: var(--journey-asterisk);
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  transition: transform 140ms ease;
+}
+
+.app-journey-star-wrap:hover .app-journey-star,
+.app-journey-star-wrap:focus-visible .app-journey-star {
+  transform: scale(1.1);
+}
+
+.app-journey-tooltip {
+  position: absolute;
+  z-index: 70;
+  top: calc(100% + 0.55rem);
+  right: 0;
+  width: 230px;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  display: grid;
+  gap: 0.22rem;
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--color-shadow) 16%, transparent);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-3px);
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.app-journey-star-wrap:hover .app-journey-tooltip,
+.app-journey-star-wrap:focus-visible .app-journey-tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.app-journey-tooltip strong {
+  color: var(--color-ink);
+  font-size: 0.76rem;
+}
+
+.sidebar-panel-toggle {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--color-ink) 16%, transparent);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  display: grid;
+  place-content: center;
+  gap: 4px;
+  cursor: pointer;
+  transition: border-color 150ms ease, background-color 150ms ease, transform 150ms ease;
+}
+
+.sidebar-panel-toggle:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 38%, transparent);
+  transform: translateY(-1px);
+}
+
+.app-sidebar {
+  position: fixed;
+  z-index: 50;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: var(--app-sidebar-width);
+  min-width: var(--app-sidebar-width);
+  max-width: var(--app-sidebar-width);
+  padding: 1rem;
+  border-right: 1px solid color-mix(in srgb, var(--color-ink) 8%, transparent);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+  transform: translateX(0);
+  transition: transform 190ms ease;
+  box-shadow: 12px 0 30px color-mix(in srgb, var(--color-shadow) 3%, transparent);
+}
+
+.layout--sidebar-closed .app-sidebar {
+  transform: translateX(-100%);
+}
+
+.app-sidebar-rail {
+  position: fixed;
+  z-index: 50;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 64px;
+  padding: 1rem 0.7rem;
+  border-right: 1px solid color-mix(in srgb, var(--color-ink) 8%, transparent);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  box-shadow: 8px 0 24px color-mix(in srgb, var(--color-shadow) 3%, transparent);
+}
+
+.sidebar-rail-nav {
+  width: 100%;
+  display: grid;
+  justify-items: center;
+  gap: 0.45rem;
+}
+
+.sidebar-rail-nav--admin {
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.sidebar-rail-link {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  color: var(--color-text);
+  display: grid;
+  place-items: center;
+  text-decoration: none;
+  transition: color 140ms ease, background-color 140ms ease, transform 140ms ease;
+}
+
+.sidebar-rail-link:hover {
+  color: var(--color-primary);
+  background: var(--color-surface-subtle);
+  transform: translateY(-1px);
+}
+
+.sidebar-rail-link--active {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.sidebar-rail-link--disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.app-main--app {
+  min-width: 0;
+  margin-left: var(--app-sidebar-width);
+  transition: margin-left 190ms ease;
+}
+
+.layout--sidebar-closed .app-main--app {
+  margin-left: 64px;
+}
+
+.route-loading {
+  min-height: calc(100vh - var(--app-header-height));
+  display: grid;
+  place-items: center;
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.sidebar-organization {
+  padding-bottom: 1.1rem;
+  border-bottom: 1px solid var(--color-border-muted);
+  display: grid;
+  gap: 0.55rem;
+}
+
+.sidebar-header {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.sidebar-organization-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-ink);
+  font-family: var(--font-serif);
+  font-size: 1.42rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-organization-name:hover {
+  color: var(--color-primary);
+}
+
+.sidebar-label {
+  margin: 0 0 0.55rem;
+  color: var(--color-muted);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.app-sidebar .org-switcher {
+  width: 100%;
+  min-width: 0;
+  padding: 0.7rem 0.75rem;
+  border: 0;
+  border-radius: 10px;
+  background: var(--color-surface-subtle);
+  box-shadow: none;
+  font-size: 0.84rem;
+}
+
+.organization-switcher-wrap {
+  width: 100%;
+  min-width: 0;
+  position: relative;
+}
+
+.location-switcher-wrap {
+  width: 100%;
+  min-width: 0;
+  position: relative;
+}
+
+.app-sidebar .org-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.app-sidebar .org-switcher > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.org-switcher-chevron {
+  color: var(--color-muted);
+  flex: 0 0 auto;
+  font-size: 0.58rem;
+}
+
+.organization-switcher-menu {
+  position: absolute;
+  z-index: 42;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 100%;
+  max-width: 100%;
+  padding: 0.45rem;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface);
+  box-shadow: 0 16px 36px color-mix(in srgb, var(--color-ink) 15%, transparent);
+}
+
+.organization-switcher-heading {
+  margin: 0;
+  padding: 0.45rem 0.55rem;
+  color: var(--color-muted);
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.organization-switcher-option,
+.organization-switcher-create {
+  width: 100%;
+  min-height: 48px;
+  padding: 0.55rem 0.6rem;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--color-ink);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.organization-switcher-option:hover,
+.organization-switcher-option--active {
+  background: var(--color-primary-soft);
+}
+
+.organization-switcher-option > span:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.organization-switcher-option strong {
+  overflow: hidden;
+  font-size: 0.8rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.organization-switcher-option small {
+  color: var(--color-muted);
+  font-size: 0.68rem;
+  text-transform: capitalize;
+}
+
+.organization-switcher-create {
+  margin-top: 0.4rem;
+  border-top: 1px solid var(--color-border-muted);
+  border-radius: 0 0 9px 9px;
+  justify-content: flex-start;
+  color: var(--color-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.organization-switcher-create:hover {
+  background: var(--color-primary-soft);
+}
+
+.organization-switcher-backdrop {
+  position: fixed;
+  z-index: 41;
+  inset: 0;
+  border: 0;
+  background: transparent;
+}
+
+.location-switcher {
+  width: 100%;
+  min-height: 40px;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-ink);
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 750;
+  text-align: left;
+}
+
+.location-switcher:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 35%, transparent);
+}
+
+.location-switcher > span:nth-child(2) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.location-switcher-pin {
+  color: var(--color-primary);
+  font-size: 1rem;
+}
+
+.location-switcher-menu {
+  position: absolute;
+  z-index: 42;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 100%;
+  max-width: 100%;
+  padding: 0.45rem;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface);
+  box-shadow: 0 16px 36px color-mix(in srgb, var(--color-ink) 15%, transparent);
+}
+
+.sidebar-nav {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.sidebar-section-toggle {
+  width: 100%;
+  padding: 0 0.15rem 0.45rem;
+  border: 0;
+  background: transparent;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.sidebar-section-toggle:hover {
+  color: var(--color-ink);
+}
+
+.sidebar-section-toggle > span:last-child {
+  font-size: 0.92rem;
+  font-weight: 500;
+}
+
+.sidebar-section-links {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.sidebar-nav--admin {
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.sidebar-nav-link {
+  min-height: 43px;
+  padding: 0.65rem 0.72rem;
+  border-radius: 10px;
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.86rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: color 140ms ease, background-color 140ms ease, transform 140ms ease;
+}
+
+.sidebar-nav-link:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-subtle);
+  transform: translateX(2px);
+}
+
+.sidebar-nav-link--active {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.sidebar-nav-link--disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.sidebar-nav-link--disabled:hover {
+  transform: none;
+}
+
+.sidebar-icon {
+  width: 19px;
+  height: 19px;
+  flex: 0 0 auto;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.sidebar-account {
+  min-width: 0;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: var(--color-surface-subtle);
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) 28px;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.sidebar-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  background: var(--color-ink);
+  color: var(--color-white);
+  display: grid;
+  place-items: center;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.sidebar-account-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.sidebar-account-copy strong {
+  overflow: hidden;
+  color: var(--color-ink);
+  font-size: 0.69rem;
+  font-weight: 750;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-account-copy span {
+  color: var(--color-muted);
+  font-size: 0.65rem;
+  text-transform: capitalize;
+}
+
+.sidebar-logout {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.sidebar-logout svg {
+  width: 16px;
+  height: 16px;
+}
+
+.sidebar-logout:hover {
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+}
+
+.sidebar-backdrop {
+  display: none;
+}
+
+/* ── App overview and separated feature pages ──────────────────────────── */
+
+.dashboard {
+  max-width: 980px;
+  padding: 3.5rem 2.5rem;
+}
+
+.dashboard-welcome {
+  max-width: 650px;
+  margin-bottom: 2rem;
+}
+
+.dashboard-welcome h1 {
+  margin: 0;
+  color: var(--color-ink);
+  font-family: var(--font-serif);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  font-weight: 500;
+  letter-spacing: -0.04em;
+}
+
+.dashboard-welcome > p:not(.dashboard-kicker) {
+  margin: 0.7rem 0 0;
+  color: var(--color-muted);
+  line-height: 1.65;
+}
+
+.dashboard-widget-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.dashboard-widget {
+  position: relative;
+  min-height: 176px;
+  padding: 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--color-ink) 9%, transparent);
+  border-radius: var(--radius-card);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-decoration: none;
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--color-shadow) 4%, transparent);
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.dashboard-widget:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 32%, transparent);
+  box-shadow: var(--shadow-card);
+  transform: translateY(-2px);
+}
+
+.dashboard-widget-icon {
+  width: 38px;
+  height: 38px;
+  margin-bottom: 1.1rem;
+  border-radius: 10px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  display: grid;
+  place-items: center;
+}
+
+.dashboard-widget-copy {
+  display: grid;
+  align-items: start;
+}
+
+.dashboard-widget h2 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 1rem;
+}
+
+.dashboard-widget p {
+  margin: 0.45rem 2rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.83rem;
+  line-height: 1.55;
+}
+
+.dashboard-widget .status-pill {
+  width: fit-content;
+  margin-top: 0.8rem;
+}
+
+.dashboard-widget-arrow {
+  position: absolute;
+  right: 1.25rem;
+  bottom: 1.2rem;
+  color: var(--color-primary);
+  font-size: 1.2rem;
+  transition: transform 150ms ease;
+}
+
+.dashboard-widget:hover .dashboard-widget-arrow {
+  transform: translateX(3px);
+}
+
+.portal-page-heading {
+  margin-bottom: 1.5rem;
+}
+
+.portal-page-heading h1 {
+  margin: 0;
+  color: var(--color-ink);
+  font-family: var(--font-serif);
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 500;
+  letter-spacing: -0.035em;
+}
+
+.portal-page-heading > p:not(.dashboard-kicker) {
+  max-width: 650px;
+  margin: 0.55rem 0 0;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.portal-card {
+  padding: 1.4rem;
+  border: 1px solid color-mix(in srgb, var(--color-ink) 9%, transparent);
+  border-radius: var(--radius-card);
+  background: var(--color-surface);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--color-shadow) 4%, transparent);
+}
+
+.portal-card-heading,
+.settings-section-heading {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.portal-card-heading h2,
+.settings-section-heading .settings-heading {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 1rem;
+}
+
+.portal-card-description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.86rem;
+  line-height: 1.6;
+}
+
+.portal-count {
+  min-width: 24px;
+  height: 24px;
+  padding: 0 0.45rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+  color: var(--color-muted);
+  display: grid;
+  place-items: center;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.status-pill {
+  width: fit-content;
+  padding: 0.28rem 0.55rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.67rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.status-pill--soon {
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.owner-feature-page {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.owner-feature-page .initiatives-manager {
+  margin: 0;
+}
+
+.initiatives-manager-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.initiatives-public-link {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-decoration: none;
+}
+
+.initiatives-public-link svg {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+}
+
+.initiative-create-selects {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.initiative-location-badge {
+  color: var(--color-primary);
+  font-weight: 800;
+}
+
+.board-location-name {
+  width: fit-content;
+  margin: 0.35rem 0 0;
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+/* ── Location administration ───────────────────────────────────────────── */
+
+.locations-page {
+  width: min(100%, 980px);
+  margin: 0 auto;
+  padding: 3.5rem 2.5rem;
+}
+
+.location-create-card {
+  margin-bottom: 1rem;
+}
+
+.location-create-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.location-create-fields {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.location-create-field {
+  min-width: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.location-create-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.location-card-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.location-card-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.location-title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.location-card h2 {
+  margin: 0;
+  color: var(--color-ink);
+  font-size: 1.08rem;
+}
+
+.location-card-heading p {
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.78rem;
+}
+
+.location-card-actions {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.location-public-links {
+  margin-top: 1.1rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--color-border-muted);
+  display: grid;
+  gap: 0.55rem;
+}
+
+.location-public-link {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.location-public-link > span {
+  color: var(--color-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.location-public-link input {
+  min-width: 0;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 9px;
+  background: var(--color-surface-subtle);
+  color: var(--color-text);
+  font-family: monospace;
+  font-size: 0.72rem;
+}
+
+.member-location-access {
+  position: relative;
+}
+
+.member-location-access summary {
+  width: fit-content;
+  padding: 0.38rem 0.55rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 8px;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 800;
+  list-style: none;
+  white-space: nowrap;
+}
+
+.member-location-menu {
+  position: absolute;
+  z-index: 12;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 290px;
+  padding: 0.7rem;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface);
+  display: grid;
+  gap: 0.55rem;
+  box-shadow: 0 14px 34px color-mix(in srgb, var(--color-shadow) 16%, transparent);
+}
+
+.member-location-option {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--color-text);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.member-location-option .role-select {
+  padding: 0.35rem;
+  font-size: 0.7rem;
+}
+
+.member-all-locations {
+  color: var(--color-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+/* ── Feed and admin scaffolds ───────────────────────────────────────────── */
+
+.feed-page {
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  padding: 3.5rem 2.5rem;
+}
+
+.feed-layout {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.feed-workspace,
+.feed-publish-card {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.feed-workspace-heading,
+.feed-section-heading,
+.feed-draft-panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.feed-workspace-heading h2,
+.feed-section-heading h3,
+.feed-draft-panel-heading h4 {
+  margin: 0.35rem 0 0;
+  color: var(--color-ink);
+}
+
+.feed-workspace-heading p,
+.feed-section-heading p,
+.feed-draft-panel-heading p {
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.feed-master-section {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.feed-master-section .feed-media-picker {
+  margin-bottom: 0.25rem;
+}
+
+.feed-wordsmith-bar {
+  padding: 0.85rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 18%, transparent);
+  border-radius: 12px;
+  background: var(--color-primary-soft);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.feed-wordsmith-bar > div {
+  min-width: 0;
+  display: grid;
+  gap: 0.15rem;
+}
+
+.feed-wordsmith-bar strong {
+  color: var(--color-ink);
+  font-size: 0.82rem;
+}
+
+.feed-wordsmith-bar span {
+  color: var(--color-muted);
+  font-size: 0.74rem;
+}
+
+.feed-drafts-section {
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border-muted);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.feed-selection-count {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+  color: var(--color-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.feed-draft-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.feed-draft-tab {
+  min-width: 0;
+  padding: 0.65rem 0.7rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  font-size: 0.77rem;
+  font-weight: 750;
+  text-align: left;
+}
+
+.feed-draft-tab:hover,
+.feed-draft-tab--active {
+  border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.feed-draft-tab--unavailable:not(.feed-draft-tab--active) {
+  opacity: 0.62;
+}
+
+.feed-draft-tab-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  background: currentColor;
+  color: var(--color-surface);
+  display: grid;
+  place-items: center;
+  font-size: 0.66rem;
+  font-weight: 900;
+}
+
+.feed-draft-tab > span:nth-child(2) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.feed-draft-tab-check {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.feed-draft-tab-check--selected {
+  color: var(--color-primary);
+}
+
+.feed-draft-panel {
+  padding: 1rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 12px;
+  background: var(--color-surface-subtle);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feed-draft-panel-heading h4 {
+  margin-top: 0;
+  font-size: 0.96rem;
+}
+
+.feed-draft-include {
+  flex: 0 0 auto;
+  color: var(--color-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.74rem;
+  font-weight: 750;
+}
+
+.feed-platform-draft {
+  min-height: 138px;
+  margin: 0;
+  background: var(--color-surface);
+}
+
+.feed-draft-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.feed-draft-panel-footer > span {
+  color: var(--color-muted);
+  font-size: 0.72rem;
+}
+
+.feed-org-label {
+  color: var(--color-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.feed-message {
+  resize: vertical;
+}
+
+.feed-media-picker {
+  min-height: 96px;
+  margin: 0.25rem 0 1rem;
+  padding: 1rem;
+  border: 1px dashed color-mix(in srgb, var(--color-ink) 20%, transparent);
+  border-radius: 13px;
+  background: var(--color-surface-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.feed-media-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.feed-media-fields .feed-media-picker {
+  margin: 0;
+}
+
+.feed-media-url {
+  padding: 0.85rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 13px;
+  background: var(--color-surface-subtle);
+  display: grid;
+  align-content: center;
+  gap: 0.4rem;
+}
+
+.feed-media-url .field-input {
+  margin: 0;
+}
+
+.feed-media-url small {
+  color: var(--color-muted);
+  font-size: 0.7rem;
+}
+
+.feed-media-picker:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 50%, transparent);
+  background: var(--color-primary-soft);
+}
+
+.feed-media-picker input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.feed-media-picker > span:not(.feed-media-icon) {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.feed-media-picker strong {
+  color: var(--color-ink);
+  font-size: 0.86rem;
+}
+
+.feed-media-picker small {
+  color: var(--color-muted);
+  font-size: 0.75rem;
+}
+
+.feed-media-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-primary);
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.feed-file-list {
+  margin: -0.35rem 0 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.feed-file-list span {
+  max-width: 100%;
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  overflow: hidden;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.feed-channel-fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.feed-channel-fieldset legend {
+  margin-bottom: 0.55rem;
+  color: var(--color-ink);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.feed-channel-fieldset > p {
+  margin: 0.55rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.74rem;
+}
+
+.feed-channel-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.feed-channel {
+  min-height: 38px;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border-muted);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.feed-channel--selected {
+  border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.feed-channel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: currentColor;
+}
+
+.feed-schedule-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.feed-publish-toggle {
+  padding: 3px;
+  border-radius: 10px;
+  background: var(--color-surface-subtle);
+  display: flex;
+}
+
+.feed-publish-option {
+  padding: 0.5rem 0.7rem;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.feed-publish-option--active {
+  background: var(--color-surface);
+  color: var(--color-ink);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-shadow) 8%, transparent);
+}
+
+.feed-date-fields {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.feed-date-fields .field-input {
+  width: auto;
+  margin: 0;
+  padding: 0.55rem 0.65rem;
+  font-size: 0.76rem;
+}
+
+.feed-composer-actions {
+  margin-top: 1.1rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.feed-secondary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.feed-empty-state {
+  min-height: 180px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  text-align: center;
+}
+
+.feed-empty-state > span {
+  margin-bottom: 0.55rem;
+  color: var(--color-primary);
+  font-size: 1.7rem;
+}
+
+.feed-empty-state strong {
+  color: var(--color-ink);
+  font-size: 0.88rem;
+}
+
+.feed-empty-state p {
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.76rem;
+}
+
+.feed-post-list,
+.feed-connected-list {
+  display: grid;
+}
+
+.feed-post-summary,
+.feed-connected-list > div {
+  padding: 0.8rem 0;
+  border-top: 1px solid var(--color-border-muted);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.feed-post-summary:first-child,
+.feed-connected-list > div:first-child {
+  border-top: 0;
+}
+
+.feed-post-summary strong,
+.feed-connected-list strong {
+  color: var(--color-ink);
+  font-size: 0.8rem;
+}
+
+.feed-post-summary small,
+.feed-post-summary span,
+.feed-connected-list span {
+  color: var(--color-muted);
+  font-size: 0.72rem;
+}
+
+.feed-failures-card {
+  grid-column: 1 / -1;
+}
+
+.social-account-list {
+  display: grid;
+}
+
+.social-connection-count {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.65rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-subtle);
+  color: var(--color-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.social-account-row {
+  min-height: 76px;
+  padding: 0.9rem 0;
+  border-top: 1px solid var(--color-border-muted);
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.social-account-mark {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: var(--color-surface-subtle);
+  color: var(--color-primary);
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 0.73rem;
+  text-transform: uppercase;
+}
+
+.social-account-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.social-account-name-line {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.social-account-row strong {
+  color: var(--color-ink);
+  font-size: 0.84rem;
+}
+
+.social-account-row small {
+  color: var(--color-muted);
+  font-size: 0.72rem;
+}
+
+.social-account-diagnostic {
+  color: var(--color-warning) !important;
+}
+
+.social-account-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
+.social-account-actions .btn--text {
+  min-height: 36px;
+  padding-inline: 0.55rem;
+  color: var(--color-muted);
+  background: transparent;
+  border: 0;
+}
+
+.status-pill--connected {
+  color: var(--color-primary);
+  background: var(--color-surface-tint);
+}
+
+.status-pill--attention {
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
+}
+
+.social-accounts-loading {
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--color-border-muted);
+  color: var(--color-muted);
+}
+
+.social-connection-notice {
+  margin: 0.8rem 0;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 22%, transparent);
+  border-radius: 12px;
+  background: var(--color-surface-tint);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.social-connection-notice strong {
+  color: var(--color-ink);
+  font-size: 0.85rem;
+}
+
+.social-connection-notice p {
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.social-connection-notice .btn {
+  flex: 0 0 auto;
+}
+
+.social-account-footnote {
+  margin: 0;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--color-border-muted);
+  color: var(--color-muted);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.social-page-picker {
+  margin: 0.8rem 0 1rem;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 28%, transparent);
+  border-radius: 14px;
+  background: var(--color-primary-soft);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.social-page-picker > div:first-child p {
+  margin: 0.3rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.social-page-options {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.social-page-option {
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 11px;
+  background: var(--color-surface);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+}
+
+.social-page-option--selected {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 12%, transparent);
+}
+
+.social-page-option > span {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.social-page-option small {
+  color: var(--color-muted);
+  font-size: 0.72rem;
+}
+
+.social-page-picker-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+@media (max-width: 620px) {
+  .social-account-list .settings-section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .social-account-row {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .social-account-actions {
+    grid-column: 1 / -1;
+    justify-content: stretch;
+  }
+
+  .social-account-actions .btn {
+    flex: 1;
+  }
+
+  .social-connection-notice {
+    flex-direction: column;
+  }
+
+  .social-page-picker-actions {
+    align-items: stretch;
+    flex-direction: column-reverse;
+  }
+
+  .social-page-picker-actions .btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 900px) {
+  .layout--app {
+    --app-header-height: 72px;
+  }
+
+  .layout--app .topbar--app,
+  .layout--sidebar-closed .topbar--app {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .app-sidebar-rail {
+    top: var(--app-header-height);
+    width: 56px;
+    background: color-mix(in srgb, var(--color-surface) 96%, transparent);
+    box-shadow: 8px 0 20px color-mix(in srgb, var(--color-shadow) 6%, transparent);
+  }
+
+  .app-sidebar {
+    top: var(--app-header-height);
+    width: min(312px, calc(100vw - 2rem));
+    transform: translateX(-105%);
+    box-shadow: 24px 0 60px color-mix(in srgb, var(--color-shadow) 18%, transparent);
+  }
+
+  .app-sidebar--open {
+    transform: translateX(0);
+  }
+
+  .app-main--app,
+  .layout--app:not(.layout--sidebar-closed) .app-main--app {
+    margin-left: 0;
+  }
+
+  .layout--sidebar-closed .app-main--app {
+    margin-left: 56px;
+  }
+
+  .sidebar-backdrop {
+    position: fixed;
+    z-index: 45;
+    inset: 72px 0 0;
+    border: 0;
+    background: color-mix(in srgb, var(--color-ink) 28%, transparent);
+    opacity: 0;
+    pointer-events: none;
+    display: block;
+    transition: opacity 170ms ease;
+  }
+
+  .sidebar-backdrop--visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .dashboard {
+    padding: 2.25rem 1.25rem;
+  }
+
+  .owner-feature-page {
+    padding: 1.25rem 1rem 2rem;
+  }
+
+  .dashboard-widget-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .feed-page {
+    padding: 2.25rem 1.25rem;
+  }
+
+  .locations-page {
+    padding: 2.25rem 1.25rem;
+  }
+
+  .feed-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .feed-secondary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .feed-workspace-heading,
+  .feed-section-heading,
+  .feed-draft-panel-heading,
+  .feed-wordsmith-bar,
+  .feed-draft-panel-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .feed-wordsmith-bar .btn {
+    width: 100%;
+  }
+
+  .feed-draft-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .feed-media-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .review-link-row {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
+  .review-link-label {
+    white-space: normal;
+  }
+
+  .dashboard-widget-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-widget {
+    min-height: 165px;
+  }
+
+  .initiatives-manager-heading {
+    flex-direction: column;
+  }
+
+  .initiatives-public-link {
+    width: 100%;
+  }
+
+  .feed-page {
+    padding: 2rem 1rem;
+  }
+
+  .feed-schedule-row,
+  .feed-date-fields {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .feed-date-fields .field-input {
+    width: 100%;
+  }
+
+  .feed-composer-actions .btn {
+    flex: 1;
+  }
+
+  .locations-page {
+    padding: 2rem 1rem;
+  }
+
+  .location-create-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .location-create-actions .btn {
+    width: 100%;
+  }
+
+  .location-card-heading,
+  .location-public-link {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  .location-card-actions {
+    width: 100%;
+  }
+
+  .location-card-actions .btn {
+    flex: 1;
   }
 }

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -38,6 +38,14 @@
   --color-danger-hover: #a32828;
   --color-danger-text: #b33030;
   --color-danger-bg: #fde8e8;
+  --color-status-feedback: #08666a;
+  --color-status-feedback-bg: #ddf3f2;
+  --color-status-planned: #60499b;
+  --color-status-planned-bg: #ede7fa;
+  --color-status-progress: #9a6418;
+  --color-status-progress-bg: #fff0d6;
+  --color-status-shipped: #187046;
+  --color-status-shipped-bg: #dff5e7;
 
   /* Supporting neutrals */
   --color-neutral: #5e6770;


### PR DESCRIPTION
## What changed
- Adds public organization roadmaps with initiative voting, plus admin roadmap management.
- Adds organization locations, scoped access roles, location selection, and revised workspace/admin navigation.
- Reworks the portal dashboard, settings, feedback reports, review links, and responsive layout.
- Adds organization social connections and a Feed workspace for platform-specific AI drafts, scheduling, and Facebook/Instagram publishing.
- Keeps LinkedIn out of the current product surface; Facebook, Instagram, and TikTok remain the available destinations.

## Why
This turns the app into a location-aware organization platform for collecting feedback, sharing priorities, and preparing social content.

## Validation
- `backend/.venv/bin/pytest -q` — 30 passed
- `frontend/npm run build` — passed
- `frontend/npm run check:theme` — passed
- `git diff --check` — passed

## Follow-up
Live Meta publishing verification remains dependent on the connected Meta account being available after its temporary restriction clears.