### PR TITLE
Fix feed/initiative UX bugs and add org-wide feedback reports

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3208,17 +3208,20 @@ def generate_digest(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> DigestOut:
-    """Admin triggers AI generation of a digest for a date range."""
+    """Admin triggers AI generation of a digest for a date range.
+
+    Omitting location_id generates an organization-wide digest that rolls
+    up feedback across every accessible location (plus org-level feedback).
+    """
     membership, locations = resolve_location_scope(
         db,
         user,
         org_id,
         payload.location_id,
         manage=True,
-        require_single=True,
     )
     org = membership.organization
-    location = locations[0]
+    is_org_wide = payload.location_id is None
 
     if not settings.openai_api_key:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="AI generation not configured")
@@ -3226,23 +3229,28 @@ def generate_digest(
     if payload.period_start > payload.period_end:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="period_start must be on or before period_end")
 
-    location_timezone = _location_timezone(location)
-    period_start_utc = (
-        datetime.combine(payload.period_start, time.min, tzinfo=location_timezone)
-        .astimezone(timezone.utc)
-        .replace(tzinfo=None)
+    # Use the widest inclusive window across every location's local timezone
+    # so no feedback near the boundary is dropped due to timezone offsets.
+    location_timezones = [_location_timezone(location) for location in locations]
+    period_start_utc = min(
+        datetime.combine(payload.period_start, time.min, tzinfo=tz).astimezone(timezone.utc).replace(tzinfo=None)
+        for tz in location_timezones
     )
-    period_end_utc = (
-        datetime.combine(payload.period_end + timedelta(days=1), time.min, tzinfo=location_timezone)
-        .astimezone(timezone.utc)
-        .replace(tzinfo=None)
+    period_end_utc = max(
+        datetime.combine(payload.period_end + timedelta(days=1), time.min, tzinfo=tz).astimezone(timezone.utc).replace(tzinfo=None)
+        for tz in location_timezones
     )
+
+    location_ids = [location.id for location in locations]
+    location_filter = Feedback.location_id.in_(location_ids)
+    if is_org_wide and membership.role != Role.LOCATION:
+        location_filter = or_(location_filter, Feedback.location_id.is_(None))
 
     # Fetch feedback in the location's local date range (inclusive).
     feedback_rows = db.scalars(
         select(Feedback)
         .where(Feedback.organization_id == org_id)
-        .where(Feedback.location_id == location.id)
+        .where(location_filter)
         .where(Feedback.created_at >= period_start_utc)
         .where(Feedback.created_at < period_end_utc)
         .order_by(Feedback.created_at)
@@ -3265,7 +3273,7 @@ def generate_digest(
 
     digest = Digest(
         organization_id=org_id,
-        location_id=location.id,
+        location_id=None if is_org_wide else locations[0].id,
         status=DigestStatus.DRAFT,
         period_start=payload.period_start,
         period_end=payload.period_end,
@@ -3294,9 +3302,13 @@ def list_digests(
     is_admin = membership.role == Role.ADMIN
     location_ids = [location.id for location in locations]
 
+    digest_location_filter = Digest.location_id.in_(location_ids)
+    if location_id is None and membership.role != Role.LOCATION:
+        digest_location_filter = or_(digest_location_filter, Digest.location_id.is_(None))
+
     query = select(Digest).where(
         Digest.organization_id == org_id,
-        Digest.location_id.in_(location_ids),
+        digest_location_filter,
     )
     if not is_admin:
         manager_location_ids = list(
@@ -3341,9 +3353,12 @@ def get_digest(
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
 
-    _, _, location_role = require_location_access(db, user, org_id, digest.location_id)
+    if digest.location_id is not None:
+        _, _, location_role = require_location_access(db, user, org_id, digest.location_id)
+        can_view_draft = is_admin or location_role == LocationRole.MANAGER
+    else:
+        can_view_draft = is_admin
 
-    can_view_draft = is_admin or location_role == LocationRole.MANAGER
     if not can_view_draft and digest.status != DigestStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
 
@@ -3364,7 +3379,10 @@ def update_digest(
     )
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
-    require_location_access(db, user, org_id, digest.location_id, manage=True)
+    if digest.location_id is not None:
+        require_location_access(db, user, org_id, digest.location_id, manage=True)
+    else:
+        require_org_admin(db, user, org_id)
 
     if digest.status == DigestStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Published digests cannot be edited")
@@ -3396,7 +3414,10 @@ def publish_digest(
     )
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
-    require_location_access(db, user, org_id, digest.location_id, manage=True)
+    if digest.location_id is not None:
+        require_location_access(db, user, org_id, digest.location_id, manage=True)
+    else:
+        require_org_admin(db, user, org_id)
 
     if digest.status == DigestStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Digest is already published")
@@ -3423,7 +3444,10 @@ def delete_digest(
     )
     if not digest:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Digest not found")
-    require_location_access(db, user, org_id, digest.location_id, manage=True)
+    if digest.location_id is not None:
+        require_location_access(db, user, org_id, digest.location_id, manage=True)
+    else:
+        require_org_admin(db, user, org_id)
 
     db.delete(digest)
     db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -293,7 +293,7 @@ class Digest(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     organization_id: Mapped[int] = mapped_column(ForeignKey("organizations.id"), nullable=False)
-    location_id: Mapped[int] = mapped_column(ForeignKey("locations.id", ondelete="RESTRICT"), nullable=False, index=True)
+    location_id: Mapped[int | None] = mapped_column(ForeignKey("locations.id", ondelete="RESTRICT"), nullable=True, index=True)
     status: Mapped[DigestStatus] = mapped_column(SQLEnum(DigestStatus), nullable=False, default=DigestStatus.DRAFT)
     period_start: Mapped[date] = mapped_column(Date, nullable=False)
     period_end: Mapped[date] = mapped_column(Date, nullable=False)
@@ -308,13 +308,13 @@ class Digest(Base):
     published_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
 
     organization: Mapped["Organization"] = relationship(back_populates="digests")
-    location: Mapped["Location"] = relationship(back_populates="digests")
+    location: Mapped["Location | None"] = relationship(back_populates="digests")
     generator: Mapped["User"] = relationship(foreign_keys=[generated_by])
     publisher: Mapped["User | None"] = relationship(foreign_keys=[published_by])
 
     @property
     def location_name(self) -> str:
-        return self.location.name
+        return self.location.name if self.location else "All locations"
 
 
 class PasswordResetToken(Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -513,7 +513,7 @@ class DigestUpdate(BaseModel):
 class DigestOut(BaseModel):
     id: int
     organization_id: int
-    location_id: int
+    location_id: int | None
     location_name: str
     status: str
     period_start: Date

--- a/backend/migrations/versions/0017_allow_organization_level_digests.py
+++ b/backend/migrations/versions/0017_allow_organization_level_digests.py
@@ -1,0 +1,32 @@
+"""Allow feedback reports to be generated at the organization level.
+
+Revision ID: 0017
+Revises: 0016
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0017"
+down_revision = "0016"
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "digests",
+        "location_id",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Organization-wide digests cannot be represented by the legacy schema.
+    op.execute("DELETE FROM digests WHERE location_id IS NULL")
+    op.alter_column(
+        "digests",
+        "location_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )

--- a/frontend/src/components/DigestManager.jsx
+++ b/frontend/src/components/DigestManager.jsx
@@ -14,9 +14,7 @@ const HORIZONS = [
   { label: "Last 3 days", days: 3 },
   { label: "Last 7 days", days: 7 },
   { label: "Last month", days: 30 },
-  { label: "Last quarter", days: 90 },
   { label: "Last 6 months", days: 180 },
-  { label: "Last year", days: 365 },
 ];
 
 function dateInTimezoneIso(daysAgo, timezone) {
@@ -471,7 +469,7 @@ export default function DigestManager({ token, orgId, locationId, isAdmin, timez
         <div style={{ marginBottom: "1.5rem" }}>
           {!locationId && (
             <p className="message message--info" style={{ marginBottom: "0.5rem" }}>
-              Select one location to generate a report. The chart and existing reports can still roll up every location.
+              This will generate an organization-wide report rolling up every location. Choose a single location above to scope it instead.
             </p>
           )}
           {generateError && <p className="message message--error" style={{ marginBottom: "0.5rem" }}>{generateError}</p>}
@@ -479,7 +477,7 @@ export default function DigestManager({ token, orgId, locationId, isAdmin, timez
             type="button"
             className="btn btn--primary"
             onClick={handleGenerate}
-            disabled={isGenerating || !locationId}
+            disabled={isGenerating}
           >
             {isGenerating ? "Generating report…" : `Generate Report for ${selectedHorizon.label.toLowerCase()}`}
           </button>

--- a/frontend/src/components/FeedPage.jsx
+++ b/frontend/src/components/FeedPage.jsx
@@ -84,7 +84,7 @@ export default function FeedPage({
   const [activeChannel, setActiveChannel] = useState(CHANNELS[0].id);
   const [socialExpanded, setSocialExpanded] = useState(false);
   const [imageExpanded, setImageExpanded] = useState(false);
-  const [publishMode, setPublishMode] = useState("now");
+  const [scheduleExpanded, setScheduleExpanded] = useState(false);
   const [channels, setChannels] = useState([]);
   const [imageFile, setImageFile] = useState(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState("");
@@ -145,7 +145,7 @@ export default function FeedPage({
     && !selectedInstagramWithoutMedia
   );
   const canSubmit = canPublish && (
-    publishMode !== "schedule" || (scheduleDate && scheduleTime)
+    !scheduleExpanded || (scheduleDate && scheduleTime)
   );
 
   async function loadPublishingData() {
@@ -387,7 +387,7 @@ export default function FeedPage({
     }
   }
 
-  async function submitPost(submitMode = publishMode) {
+  async function submitPost(submitMode = "now") {
     const validForMode = submitMode === "draft" ? canSaveDraft : canSubmit;
     if (!validForMode || working || submitLock.current) return;
     submitLock.current = true;
@@ -396,7 +396,7 @@ export default function FeedPage({
     setNotice("");
     try {
       let scheduledAt = null;
-      if (submitMode === "schedule") {
+      if (scheduleExpanded && scheduleDate && scheduleTime) {
         scheduledAt = new Date(`${scheduleDate}T${scheduleTime}`).toISOString();
       }
       let uploadedMediaUrl = "";
@@ -420,14 +420,14 @@ export default function FeedPage({
         scheduled_at: scheduledAt,
         location_id: locationId,
       });
-      const completed = submitMode === "now"
+      const completed = !scheduledAt
         ? await publishSocialPost(token, orgId, created.id)
         : created;
       setPosts((current) => [completed, ...current.filter((post) => post.id !== completed.id)]);
       setNotice(
         submitMode === "draft"
           ? "Draft saved."
-          : submitMode === "schedule"
+          : scheduledAt
             ? "Post scheduled."
           : completed.status === "published"
             ? "Published to your Five* feed."
@@ -446,7 +446,7 @@ export default function FeedPage({
       setUploadedImage(null);
       setScheduleDate("");
       setScheduleTime("");
-      setPublishMode("now");
+      setScheduleExpanded(false);
       setSocialExpanded(false);
       setImageExpanded(false);
     } catch (err) {
@@ -645,58 +645,46 @@ export default function FeedPage({
             </div>
           </div>
 
-          <section className="feed-publish-inline" aria-labelledby="feed-timing-heading">
-            <div className="feed-section-heading">
-              <div>
-                <h3 id="feed-timing-heading">Post timing</h3>
-                <p>Post now or choose a later date. Social accounts are optional and never required.</p>
-              </div>
-            </div>
+          {selectedInstagramWithoutMedia && (
+            <p className="message message--error">Add an image link to include Instagram.</p>
+          )}
+          {error && <p className="message message--error" role="alert">{error}</p>}
+          {notice && <p className="message message--success" role="status">{notice}</p>}
 
-            <div className="feed-schedule-row">
-              <div className="feed-publish-toggle" aria-label="Publishing time">
-                <button
-                  className={publishMode === "now" ? "feed-publish-option feed-publish-option--active" : "feed-publish-option"}
-                  onClick={() => setPublishMode("now")}
-                  type="button"
-                >
-                  Now
-                </button>
-                <button
-                  className={publishMode === "schedule" ? "feed-publish-option feed-publish-option--active" : "feed-publish-option"}
-                  onClick={() => setPublishMode("schedule")}
-                  type="button"
-                >
-                  Schedule for later
-                </button>
-              </div>
-              {publishMode === "schedule" && (
-                <div className="feed-date-fields">
-                  <input
-                    className="field-input"
-                    aria-label="Schedule date"
-                    onChange={(event) => setScheduleDate(event.target.value)}
-                    type="date"
-                    value={scheduleDate}
-                  />
-                  <input
-                    className="field-input"
-                    aria-label="Schedule time"
-                    onChange={(event) => setScheduleTime(event.target.value)}
-                    type="time"
-                    value={scheduleTime}
-                  />
-                </div>
-              )}
-            </div>
+          <section className="feed-schedule-section" aria-labelledby="feed-schedule-heading">
+            <button
+              aria-expanded={scheduleExpanded}
+              className="feed-image-toggle"
+              onClick={() => setScheduleExpanded((current) => !current)}
+              type="button"
+              id="feed-schedule-heading"
+            >
+              <span aria-hidden="true">{scheduleExpanded ? "−" : "+"}</span>
+              Schedule post
+              <small>Optional</small>
+            </button>
 
-            {selectedInstagramWithoutMedia && (
-              <p className="message message--error">Add an image link to include Instagram.</p>
+            {scheduleExpanded && (
+              <div className="feed-date-fields">
+                <input
+                  className="field-input"
+                  aria-label="Schedule date"
+                  onChange={(event) => setScheduleDate(event.target.value)}
+                  type="date"
+                  value={scheduleDate}
+                />
+                <input
+                  className="field-input"
+                  aria-label="Schedule time"
+                  onChange={(event) => setScheduleTime(event.target.value)}
+                  type="time"
+                  value={scheduleTime}
+                />
+              </div>
             )}
-            {error && <p className="message message--error" role="alert">{error}</p>}
-            {notice && <p className="message message--success" role="status">{notice}</p>}
+          </section>
 
-            <div className="feed-composer-actions">
+          <div className="feed-composer-actions">
             <button
               className="btn btn--ghost"
               type="button"
@@ -709,16 +697,15 @@ export default function FeedPage({
               className="btn btn--primary"
               type="button"
               disabled={!canSubmit || working}
-              onClick={() => submitPost(publishMode)}
+              onClick={() => submitPost("now")}
             >
               {working
                 ? "Working…"
-                : publishMode === "schedule"
+                : scheduleExpanded && scheduleDate && scheduleTime
                   ? "Schedule post"
                   : "Publish to Five*"}
             </button>
-            </div>
-          </section>
+          </div>
 
           <section className={`feed-drafts-section${socialExpanded ? " feed-drafts-section--expanded" : ""}`} aria-labelledby="feed-drafts-heading">
             <button
@@ -932,7 +919,6 @@ export default function FeedPage({
               </div>
             ) : (
               <div className="feed-empty-state">
-                <span aria-hidden="true">*</span>
                 <strong>No Five* posts yet</strong>
                 <p>Published posts will appear here immediately.</p>
               </div>
@@ -956,7 +942,6 @@ export default function FeedPage({
               </div>
             ) : (
               <div className="feed-empty-state">
-                <span aria-hidden="true">◇</span>
                 <strong>No saved drafts</strong>
                 <p>Save a prepared post to finish it later.</p>
               </div>
@@ -980,7 +965,6 @@ export default function FeedPage({
               </div>
             ) : (
               <div className="feed-empty-state">
-                <span aria-hidden="true">◷</span>
                 <strong>No posts scheduled</strong>
                 <p>Your scheduled content will appear here.</p>
               </div>

--- a/frontend/src/components/InitiativesManager.jsx
+++ b/frontend/src/components/InitiativesManager.jsx
@@ -82,6 +82,7 @@ export default function InitiativesManager({
   const [isSaving, setIsSaving] = useState(false);
   const [editingId, setEditingId] = useState(null);
   const [error, setError] = useState("");
+  const [deletingId, setDeletingId] = useState(null);
 
   useEffect(() => {
     let active = true;
@@ -145,12 +146,12 @@ export default function InitiativesManager({
   }
 
   async function handleDelete(initiative) {
-    if (!window.confirm(`Delete "${initiative.title}"? This cannot be undone.`)) return;
     setIsSaving(true);
     setError("");
     try {
       await deleteOrganizationInitiative(token, orgId, initiative.id);
       setInitiatives((current) => current.filter((item) => item.id !== initiative.id));
+      setDeletingId(null);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -255,8 +256,18 @@ export default function InitiativesManager({
                   </div>
                   {isAdmin && (
                     <div className="initiative-admin-actions">
-                      <button className="btn btn--ghost btn--sm" type="button" disabled={isSaving} onClick={() => setEditingId(initiative.id)}>Edit</button>
-                      <button className="btn btn--ghost btn--sm initiative-delete-button" type="button" disabled={isSaving} onClick={() => handleDelete(initiative)}>Delete</button>
+                      {deletingId === initiative.id ? (
+                        <>
+                          <span>Delete "{initiative.title}"?</span>
+                          <button className="btn btn--danger btn--sm" type="button" disabled={isSaving} onClick={() => handleDelete(initiative)}>Confirm</button>
+                          <button className="btn btn--ghost btn--sm" type="button" disabled={isSaving} onClick={() => setDeletingId(null)}>Cancel</button>
+                        </>
+                      ) : (
+                        <>
+                          <button className="btn btn--ghost btn--sm" type="button" disabled={isSaving} onClick={() => setEditingId(initiative.id)}>Edit</button>
+                          <button className="btn btn--ghost btn--sm initiative-delete-button" type="button" disabled={isSaving} onClick={() => setDeletingId(initiative.id)}>Delete</button>
+                        </>
+                      )}
                     </div>
                   )}
                 </>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5501,9 +5501,9 @@ html {
 }
 
 .owner-feature-page {
-  width: min(100%, 920px);
+  width: min(100%, 980px);
   margin: 0 auto;
-  padding: 2rem;
+  padding: 3.5rem 2.5rem;
 }
 
 .owner-feature-page .initiatives-manager {
@@ -5812,7 +5812,7 @@ html {
 /* ── Feed and admin scaffolds ───────────────────────────────────────────── */
 
 .feed-page {
-  width: min(100%, 1120px);
+  width: min(100%, 980px);
   margin: 0 auto;
   padding: 3.5rem 2.5rem;
 }
@@ -6960,7 +6960,7 @@ html {
   }
 
   .owner-feature-page {
-    padding: 1.25rem 1rem 2rem;
+    padding: 2.25rem 1.25rem;
   }
 
   .dashboard-widget-grid {
@@ -7179,6 +7179,10 @@ html {
   }
 
   .locations-page {
+    padding: 2rem 1rem;
+  }
+
+  .owner-feature-page {
     padding: 2rem 1rem;
   }
 


### PR DESCRIPTION
## Summary
- Feed composer: replace suppressed `window.confirm()` on initiative delete with an inline confirm/cancel UI; make post scheduling an optional collapsible section decoupled from Save/Publish actions
- Unify container width/padding across the Feed, Roadmap, and Feedback pages so they share one consistent shell
- Allow generating feedback reports at the organization level (rolling up every location) instead of requiring a single location — adds a migration to make `digests.location_id` nullable, and updates access checks for org-wide digests
- Trim the feedback-report time horizon pills to day / 3-day / week / month / 6-month

## Test plan
- [x] Backend test suite passes (`pytest`, 49 passed)
- [x] Manually verified initiative delete confirmation flow in the browser
- [x] Manually verified Feed post-scheduling disclosure and Save/Publish behavior
- [x] Manually verified Feed/Roadmap/Feedback page container alignment
- [x] Manually verified org-wide report generation end-to-end (aggregated feedback count + AI-generated summary)
- [ ] Run `alembic upgrade head` against the production database after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)